### PR TITLE
Add itunes shared secret as an option of itunes validator ..?

### DIFF
--- a/src/ReceiptValidator/iTunes/Validator.php
+++ b/src/ReceiptValidator/iTunes/Validator.php
@@ -28,6 +28,13 @@ class Validator
 
 
     /**
+     * itunes shared secret ie. password
+     *
+     * @var string
+     */
+    protected $_iStoreSharedSecret = null;
+
+    /**
      * Guzzle http client
      *
      * @var \Guzzle\Http\Client
@@ -68,6 +75,21 @@ class Validator
         }
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIStoreSharedSecret()
+    {
+        return $this->_iStoreSharedSecret;
+    }
+    /**
+     * @param string $iStoreSharedSecret
+     */
+    public function setIStoreSharedSecret($iStoreSharedSecret)
+    {
+        $this->_iStoreSharedSecret = $iStoreSharedSecret;
     }
 
     /**
@@ -114,9 +136,13 @@ class Validator
      */
     private function encodeRequest()
     {
-        return json_encode(array(
-            'receipt-data' => $this->getReceiptData()
-        ));
+        $request = array('receipt-data' => $this->getReceiptData());
+
+        if( !is_null( $this->getIStoreSharedSecret() ) ) {
+            $request['password'] = $this->getIStoreSharedSecret();
+        }
+
+        return json_encode( $request );
     }
 
     /**
@@ -126,11 +152,15 @@ class Validator
      *
      * @return Response
      */
-    public function validate($receiptData = null)
+    public function validate($receiptData = null, $iStoreSharedSecret = null)
     {
 
         if ($receiptData != null) {
             $this->setReceiptData($receiptData);
+        }
+
+        if ($iStoreSharedSecret != null) {
+            $this->setIStoreSharedSecret($receiptData);
         }
 
         $httpResponse = $this->getClient()->post(null, null, $this->encodeRequest(), array('verify' => false))->send();

--- a/tests/iTunes/ValidatorTest.php
+++ b/tests/iTunes/ValidatorTest.php
@@ -40,7 +40,13 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
     
         $this->assertEquals('test-data', $this->validator->getReceiptData());
     }
-    
+
+    public function testsetIStoreSharedSecret()
+    {
+        $this->validator->setIStoreSharedSecret('test-shared-secret');
+
+        $this->assertEquals('test-shared-secret', $this->validator->getIStoreSharedSecret());
+    }
     
     public function testValidateWithInvalidReceipt()
     {


### PR DESCRIPTION
I think this is the only thing missing from your package, sometimes it's necessary to send "shared secret" ie. password when validating iStore receipt. I've added necessary methods and properties and basic tested getter/setter on a property. 

Let me know what you think.

Thanks
