### PR TITLE
Fix failure to return correct status code in Response

### DIFF
--- a/src/ReceiptValidator/iTunes/Response.php
+++ b/src/ReceiptValidator/iTunes/Response.php
@@ -223,6 +223,8 @@ class Response
                     $this->_bundle_id = $jsonResponse['receipt']['bid'];
                 }
             }
+        } elseif (array_key_exists('status', $jsonResponse)) {
+            $this->_code = $jsonResponse['status'];
         } else {
             $this->_code = self::RESULT_DATA_MALFORMED;
         }

--- a/tests/iTunes/ResponseTest.php
+++ b/tests/iTunes/ResponseTest.php
@@ -19,13 +19,23 @@ class ResponseTest extends PHPUnit_Framework_TestCase
         $response = new Response(array('status' => 21002, 'receipt' => []));
         
         $this->assertFalse($response->isValid(), 'receipt must be invalid');
+        $this->assertEquals(21002, $response->getResultCode(), 'receipt result code must match');
     }
     
+    public function testReceiptSentToWrongEndpoint()
+    {
+        $response = new Response(array('status' => 21007));
+
+        $this->assertFalse($response->isValid(), 'receipt must be invalid');
+        $this->assertEquals(21007, $response->getResultCode(), 'receipt result code must match');
+    }
+
     public function testValidReceipt()
     {
         $response = new Response(array('status' => 0, 'receipt' => []));
     
         $this->assertTrue($response->isValid(), 'receipt must be valid');
+        $this->assertEquals(0, $response->getResultCode(), 'receipt result code must match');
     }
     
 }


### PR DESCRIPTION
While testing in-app purchase in "review" environment, the code failed to re-try validation against Sandbox because it does not set correct `_code` in Response object when the error comes back from Apple's servers.
When the error comes back from Apple it only contains `status` code, and no `receipt` which triggers code to always return `RESULT_DATA_MALFORMED` instead of the real one.