### PR TITLE
Scrutinizer support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,18 @@
+filter:
+    paths: [src/*]
+    excluded_paths: [vendor/*, tests/*]
+before_commands:
+    - 'composer install --dev --prefer-source'
+tools:
+    external_code_coverage: true
+    php_mess_detector: true
+    php_code_sniffer: true
+    sensiolabs_security_checker: true
+    php_code_coverage: true
+    php_pdepend: true
+    php_loc:
+        enabled: true
+        excluded_dirs: [vendor, tests]
+    php_cpd:
+        enabled: true
+        excluded_dirs: [vendor, tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ script:
 
 after_script:
   - php vendor/bin/coveralls -v
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true" bootstrap="./tests/Bootstrap.php">
   <logging>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
     <log type="coverage-php" target="build/logs/coverage.cov"/>
     <log type="coverage-clover" target="build/logs/clover.xml"/>
     <log type="coverage-html" target="build/logs/coverage"/>


### PR DESCRIPTION
Added scrutinizer support in order to provide extended code quality inspection. IFAIK it can replace coveralls as well if you aware.
An example inspection looks like this: https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/?branch=scrutinizer-clean

It has some badges too: [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/badges/quality-score.png?b=scrutinizer-clean)](https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/?branch=scrutinizer-clean) [![Code Coverage](https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/badges/coverage.png?b=scrutinizer-clean)](https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/?branch=scrutinizer-clean) [![Build Status](https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/badges/build.png?b=scrutinizer-clean)](https://scrutinizer-ci.com/g/AlexeyKupershtokh/store-receipt-validator/build-status/scrutinizer-clean).

I used this article to achieve code coverage support: https://www.adayinthelifeof.nl/2013/11/20/external-code-coverage-with-travis-scrutinizer/

Meybe some hooks should be configured on github in order to achieve automatic inspection on commit.