### PR TITLE
Add Google Play validator using service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ try {
 // success
 ```
 
+Or [Using a service account](https://developers.google.com/android-publisher/getting_started#using_a_service_account)
+
+Create service account [Service Account flow](https://developers.google.com/identity/protocols/OAuth2ServiceAccount)
+
+```php
+use ReceiptValidator\GooglePlay\ServiceAccountValidator as PlayValidator;
+$validator = new PlayValidator([
+    'client_email' => 'xxxxxx@developer.gserviceaccount.com',
+    'p12_key_path' => 'MyProject.p12',
+]);
+
+try {
+  $response = $validator->setPackageName('PACKAGE_NAME')
+    ->setProductId('PRODUCT_ID')
+    ->setPurchaseToken('PURCHASE_TOKEN')
+    ->validate();
+} catch (Exception $e){
+  var_dump($e->getMessage());
+  // example message: Error calling GET ....: (404) Product not found for this application.
+}
+// success
+```
+
 
 ### Amazon App Store ###
 

--- a/examples/test_play_service_account.php
+++ b/examples/test_play_service_account.php
@@ -1,0 +1,33 @@
+<?php
+
+error_reporting(E_ALL | E_STRICT);
+ini_set('display_errors', 1);
+
+$root = realpath(dirname(dirname(__FILE__)));
+$library = "$root/library";
+
+$path = array($library, get_include_path());
+set_include_path(implode(PATH_SEPARATOR, $path));
+
+require_once $root . '/vendor/autoload.php';
+
+use ReceiptValidator\GooglePlay\ServiceAccountValidator as PlayValidator;
+
+// google authencation 
+$client_email = 'xxxxxx@developer.gserviceaccount.com';
+$p12_key_path = 'MyProject.p12';
+
+// receipt data
+$package_name = 'com.example';
+$product_id = 'coins_10000';
+$purchase_token = 'xxxxxx';
+
+$validator = new PlayValidator(['client_email' => $client_email, 'p12_key_path' => $p12_key_path]);
+
+try {
+  $response = $validator->setPackageName($package_name)->setProductId($product_id)->setPurchaseToken($purchase_token)->validate();
+} catch (Exception $e) {
+  echo 'got error = ' . $e->getMessage() . PHP_EOL;
+}
+
+print_R($response);

--- a/src/GooglePlay/AbstractValidator.php
+++ b/src/GooglePlay/AbstractValidator.php
@@ -10,7 +10,7 @@ abstract class AbstractValidator
     /**
     * google client
     *
-    * @var Google_Client
+    * @var \Google_Client
     */
     protected $_client = null;
 

--- a/src/GooglePlay/AbstractValidator.php
+++ b/src/GooglePlay/AbstractValidator.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace ReceiptValidator\GooglePlay;
+
+abstract class AbstractValidator
+{
+    const TYPE_PURCHASE = 1;
+    const TYPE_SUBSCRIPTION = 2;
+
+    /**
+    * google client
+    *
+    * @var Google_Client
+    */
+    protected $_client = null;
+
+    /**
+     * @var \Google_Service_AndroidPublisher
+     */
+    protected $_androidPublisherService = null;
+
+    /**
+     * @var string
+     */
+    protected $_package_name = null;
+
+    /**
+     * @var string
+     */
+    protected $_purchase_token = null;
+
+    /**
+     * @var int
+     */
+    protected $_purchase_type = self::TYPE_PURCHASE;
+
+    /**
+     * @var string
+     */
+    protected $_product_id = null;
+
+    public function __construct($options = [])
+    {
+        $this->initClient($options);
+        $this->_androidPublisherService = new \Google_Service_AndroidPublisher($this->_client);
+    }
+
+    abstract protected function initClient($options = []);
+
+    /**
+     *
+     * @param string $package_name
+     * @return \ReceiptValidator\GooglePlay\Validator
+     */
+    public function setPackageName($package_name)
+    {
+        $this->_package_name = $package_name;
+
+        return $this;
+    }
+
+    /**
+     *
+     * @param string $purchase_token
+     * @return \ReceiptValidator\GooglePlay\Validator
+     */
+    public function setPurchaseToken($purchase_token)
+    {
+        $this->_purchase_token = $purchase_token;
+
+        return $this;
+    }
+
+    /**
+     *
+     * @param int $purchase_type
+     * @return \ReceiptValidator\GooglePlay\Validator
+     */
+    public function setPurchaseType($purchase_type)
+    {
+        $this->_purchase_type = $purchase_type;
+
+        return $this;
+    }
+
+    /**
+     *
+     * @param string $product_id
+     * @return \ReceiptValidator\GooglePlay\Validator
+     */
+    public function setProductId($product_id)
+    {
+        $this->_product_id = $product_id;
+
+        return $this;
+    }
+
+    public function validate()
+    {
+        switch ($this->_purchase_type) {
+            case self::TYPE_SUBSCRIPTION:
+                $request = $this->_androidPublisherService->purchases_subscriptions;
+                break;
+            default:
+                $request = $this->_androidPublisherService->purchases_products;
+        }
+
+        $response = $request->get(
+              $this->_package_name, $this->_product_id, $this->_purchase_token
+        );
+
+        return $response;
+    }
+}

--- a/src/GooglePlay/ServiceAccountValidator.php
+++ b/src/GooglePlay/ServiceAccountValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ReceiptValidator\GooglePlay;
+
+class ServiceAccountValidator extends AbstractValidator
+{
+    protected function initClient($options = [])
+    {
+        $credentials = new \Google_Auth_AssertionCredentials(
+            $options['client_email'],
+            [\Google_Service_AndroidPublisher::ANDROIDPUBLISHER],
+            $options['p12_key_path']
+        );
+        $this->_client = new \Google_Client();
+        $this->_client->setAssertionCredentials($credentials);
+        if ($this->_client->getAuth()->isAccessTokenExpired()) {
+            $this->_client->getAuth()->refreshTokenWithAssertion();
+        }
+    }
+}

--- a/src/GooglePlay/Validator.php
+++ b/src/GooglePlay/Validator.php
@@ -3,137 +3,32 @@ namespace ReceiptValidator\GooglePlay;
 
 use ReceiptValidator\RunTimeException as RunTimeException;
 
-class Validator
+class Validator extends AbstractValidator
 {
-  const TYPE_PURCHASE = 1;
-  const TYPE_SUBSCRIPTION = 2;
+    protected function initClient($options = [])
+    {
+        $this->_client = new \Google_Client();
+        $this->_client->setClientId($options['client_id']);
+        $this->_client->setClientSecret($options['client_secret']);
 
-  /**
-   * google client
-   *
-   * @var Google_Client
-   */
-  protected $_client = null;
+        $cached_access_token_path = sys_get_temp_dir() . '/' . 'googleplay_access_token_' . md5($options['client_id']) . '.txt';
 
-  /**
-   * @var \Google_Service_AndroidPublisher
-   */
-  protected $_androidPublisherService = null;
+        touch($cached_access_token_path);
+        chmod($cached_access_token_path, 0770);
 
-  /**
-   * @var string
-   */
-  protected $_package_name = null;
+        try {
+            $this->_client->setAccessToken(file_get_contents($cached_access_token_path));
+        } catch (\Exception $e) {
+          // skip exceptions when the access token is not valid
+        }
 
-  /**
-   * @var string
-   */
-  protected $_purchase_token = null;
-
-  /**
-   * @var int
-   */
-  protected $_purchase_type = self::TYPE_PURCHASE;
-
-  /**
-   * @var string
-   */
-  protected $_product_id = null;
-
-  public function __construct(array $options = array())
-  {
-    $this->_client = new \Google_Client();
-    $this->_client->setClientId($options['client_id']);
-    $this->_client->setClientSecret($options['client_secret']);
-
-    $cached_access_token_path = sys_get_temp_dir() . '/' . 'googleplay_access_token_' . md5($options['client_id']) . '.txt';
-
-    touch($cached_access_token_path);
-    chmod($cached_access_token_path, 0770);
-
-    try {
-      $this->_client->setAccessToken(file_get_contents($cached_access_token_path));
-    } catch (\Exception $e) {
-      // skip exceptions when the access token is not valid
+        try {
+            if ($this->_client->isAccessTokenExpired()) {
+                $this->_client->refreshToken($options['refresh_token']);
+                file_put_contents($cached_access_token_path, $this->_client->getAccessToken());
+            }
+        } catch (\Exception $e) {
+            throw new RuntimeException('Failed refreshing access token - ' . $e->getMessage());
+        }
     }
-
-    try {
-      if ($this->_client->isAccessTokenExpired()) {
-        $this->_client->refreshToken($options['refresh_token']);
-        file_put_contents($cached_access_token_path, $this->_client->getAccessToken());
-      }
-    } catch (\Exception $e) {
-      throw new RuntimeException('Failed refreshing access token - ' . $e->getMessage());
-    }
-
-    $this->_androidPublisherService = new \Google_Service_AndroidPublisher($this->_client);
-
-  }
-
-
-  /**
-   *
-   * @param string $package_name
-   * @return \ReceiptValidator\GooglePlay\Validator
-   */
-  public function setPackageName($package_name)
-  {
-    $this->_package_name = $package_name;
-
-    return $this;
-  }
-
-  /**
-   *
-   * @param string $purchase_token
-   * @return \ReceiptValidator\GooglePlay\Validator
-   */
-  public function setPurchaseToken($purchase_token)
-  {
-    $this->_purchase_token = $purchase_token;
-
-    return $this;
-  }
-
-  /**
-   *
-   * @param int $purchase_type
-   * @return \ReceiptValidator\GooglePlay\Validator
-   */
-  public function setPurchaseType($purchase_type)
-  {
-    $this->_purchase_type = $purchase_type;
-
-    return $this;
-  }
-
-  /**
-   *
-   * @param string $product_id
-   * @return \ReceiptValidator\GooglePlay\Validator
-   */
-  public function setProductId($product_id)
-  {
-    $this->_product_id = $product_id;
-
-    return $this;
-  }
-
-
-  public function validate()
-  {
-    switch ($this->_purchase_type) {
-      case self::TYPE_SUBSCRIPTION:
-        $request = $this->_androidPublisherService->purchases_subscriptions;
-        break;
-      default:
-        $request = $this->_androidPublisherService->purchases_products;
-    }
-
-    $response = $request->get(
-        $this->_package_name, $this->_product_id, $this->_purchase_token
-    );
-
-    return $response;
-  }
 }


### PR DESCRIPTION
Trying to add another way Google Play purchase validation using service accounts.
@aporat please review, thx

[Google Play Developer Api](https://developers.google.com/android-publisher/getting_started#using_a_service_account)
[Using OAuth 2.0 for Server to Server Applications](https://developers.google.com/api-client-library/php/auth/service-accounts)