### PR TITLE
Fix iTunes Response return types, adding test for latest receipt

### DIFF
--- a/src/iTunes/Response.php
+++ b/src/iTunes/Response.php
@@ -52,7 +52,7 @@ class Response
    *
    * @var string
    */
-  protected $_bundle_id = null;
+  protected $_bundle_id;
 
   /**
    * receipt info
@@ -64,16 +64,16 @@ class Response
   /**
    * latest receipt (needs for auto-renewable subscriptions)
    *
-   * @var array
+   * @var string
    */
-  protected $_latest_receipt =  array();
+  protected $_latest_receipt;
 
   /**
    * latest receipt info (needs for auto-renewable subscriptions)
    *
-   * @var string
+   * @var array
    */
-  protected $_latest_receipt_info = null;
+  protected $_latest_receipt_info;
 
   /**
    * purhcases info
@@ -160,7 +160,7 @@ class Response
   /**
    * Get the bundle id assoicated with the receipt
    *
-   * @return array
+   * @return string
    */
   public function getBundleId()
   {
@@ -185,7 +185,9 @@ class Response
    * Parse JSON Response
    *
    * @param string $jsonResponse
-   * @return Message
+   *
+   * @return Response
+   * @throws RunTimeException
    */
   public function parseJsonResponse($jsonResponse)
   {

--- a/tests/iTunes/ResponseTest.php
+++ b/tests/iTunes/ResponseTest.php
@@ -38,4 +38,20 @@ class iTunesResponseTest extends PHPUnit_Framework_TestCase
     $this->assertEquals(0, $response->getResultCode(), 'receipt result code must match');
   }
 
+  public function testReceiptWithLatestReceiptInfo()
+  {
+    $jsonResponseString = file_get_contents(__DIR__ . '/fixtures/inAppPurchaseResponse.json');
+    $jsonResponseArray = json_decode($jsonResponseString, true);
+
+    $response = new Response($jsonResponseArray);
+
+    $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $response->getLatestReceiptInfo());
+    $this->assertEquals($jsonResponseArray['latest_receipt_info'], $response->getLatestReceiptInfo(), 'latest receipt info must match');
+
+    $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_STRING, $response->getLatestReceipt());
+    $this->assertEquals($jsonResponseArray['latest_receipt'], $response->getLatestReceipt(), 'latest receipt must match');
+
+    $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_STRING, $response->getBundleId());
+    $this->assertEquals($jsonResponseArray['receipt']['bundle_id'], $response->getBundleId(), 'receipt bundle id must match');
+  }
 }

--- a/tests/iTunes/fixtures/inAppPurchaseResponse.json
+++ b/tests/iTunes/fixtures/inAppPurchaseResponse.json
@@ -1,0 +1,84 @@
+{
+  "environment": "Sandbox",
+  "latest_receipt": "MILFMwYJKoZIhvcNAQcCoILFJDCCxSACAQExCzAJBgUrDgMCGgUAMIK05AYJKoZIhvcNAQcBoIK01QSCtNExgrTNMAoCAQgCAQEEAhYAMAoCARICAQEEAhYAMAoCARMCAQEEAgwAMAoCARQCAQEEAgwAMAsCAQECAQEEAwIBADA",
+  "latest_receipt_info": [
+    {
+      "expires_date": "2014-03-12 10:18:05 Etc\/GMT",
+      "expires_date_ms": 1394619485000,
+      "expires_date_pst": "2014-03-12 03:18:05 America\/Los_Angeles",
+      "is_trial_period": false,
+      "original_purchase_date": "2014-03-12 10:15:06 Etc\/GMT",
+      "original_purchase_date_ms": 1394619306000,
+      "original_purchase_date_pst": "2014-03-12 03:15:06 America\/Los_Angeles",
+      "original_transaction_id": 1000000093384828,
+      "product_id": "myapp.1",
+      "purchase_date": "2014-03-25 12:21:23 Etc\/GMT",
+      "purchase_date_ms": 1395750083000,
+      "purchase_date_pst": "2014-03-25 05:21:23 America\/Los_Angeles",
+      "quantity": 1,
+      "transaction_id": 1000000104232856,
+      "web_order_line_item_id": 1000000027948608
+    },
+    {
+      "expires_date": "2013-11-14 10:23:43 Etc\/GMT",
+      "expires_date_ms": 1384424623000,
+      "expires_date_pst": "2013-11-14 02:23:43 America\/Los_Angeles",
+      "original_purchase_date": "2013-11-14 10:20:44 Etc\/GMT",
+      "original_purchase_date_ms": 1384424444000,
+      "original_purchase_date_pst": "2013-11-14 02:20:44 America\/Los_Angeles",
+      "original_transaction_id": 1000000093384828,
+      "product_id": "myapp.2",
+      "purchase_date": "2014-03-29 05:37:36 Etc\/GMT",
+      "purchase_date_ms": 1396071456569,
+      "purchase_date_pst": "2014-03-28 22:37:36 America\/Los_Angeles",
+      "quantity": 1,
+      "transaction_id": 1000000093384828,
+      "web_order_line_item_id": 1000000027562376
+    }
+  ],
+  "receipt": {
+    "adam_id": 0,
+    "app_item_id": 0,
+    "application_version": 1,
+    "bundle_id": "com.myapp",
+    "download_id": 0,
+    "in_app": [
+      {
+        "is_trial_period": false,
+        "original_purchase_date": "2015-05-24 01:06:58 Etc\/GMT",
+        "original_purchase_date_ms": 1432429618000,
+        "original_purchase_date_pst": "2015-05-23 18:06:58 America\/Los_Angeles",
+        "original_transaction_id": 1000000156455961,
+        "product_id": "myapp.1",
+        "purchase_date": "2015-05-24 01:06:58 Etc\/GMT",
+        "purchase_date_ms": 1432429618000,
+        "purchase_date_pst": "2015-05-23 18:06:58 America\/Los_Angeles",
+        "quantity": 1,
+        "transaction_id": 1000000156455961
+      },
+      {
+        "is_trial_period": false,
+        "original_purchase_date": "2015-05-20 17:41:12 Etc\/GMT",
+        "original_purchase_date_ms": 1432143672000,
+        "original_purchase_date_pst": "2015-05-20 10:41:12 America\/Los_Angeles",
+        "original_transaction_id": 1000000156014803,
+        "product_id": "myapp.2",
+        "purchase_date": "2015-05-20 17:41:12 Etc\/GMT",
+        "purchase_date_ms": 1432143672000,
+        "purchase_date_pst": "2015-05-20 10:41:12 America\/Los_Angeles",
+        "quantity": 1,
+        "transaction_id": 1000000156014803
+      }
+    ],
+    "original_application_version": "1.0",
+    "original_purchase_date": "2013-08-01 07:00:00 Etc\/GMT",
+    "original_purchase_date_ms": 1375340400000,
+    "original_purchase_date_pst": "2013-08-01 00:00:00 America\/Los_Angeles",
+    "receipt_type": "ProductionSandbox",
+    "request_date": "2015-05-24 16:31:18 Etc\/GMT",
+    "request_date_ms": 1432485078143,
+    "request_date_pst": "2015-05-24 09:31:18 America\/Los_Angeles",
+    "version_external_identifier": 0
+  },
+  "status": 0
+}


### PR DESCRIPTION
There difference between variable types in phpdoc and function return. I try to fix this and create test to make sure that we return it correctly. 

'latest_receipt_info' key contains list of previous app purchase (array)
'latest_receipt' contains encoded date of latest purchase. (string)
'bundle_id' receipt bundle id (string)