### PR TITLE
Fix service account validation key loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Create service account [Service Account flow](https://developers.google.com/iden
 use ReceiptValidator\GooglePlay\ServiceAccountValidator as PlayValidator;
 $validator = new PlayValidator([
     'client_email' => 'xxxxxx@developer.gserviceaccount.com',
-    'p12_key_path' => file_get_contents('MyProject.p12'),
+    'p12_key_path' => 'MyProject.p12',
 ]);
 
 try {

--- a/src/GooglePlay/ServiceAccountValidator.php
+++ b/src/GooglePlay/ServiceAccountValidator.php
@@ -9,7 +9,7 @@ class ServiceAccountValidator extends AbstractValidator
         $credentials = new \Google_Auth_AssertionCredentials(
             $options['client_email'],
             [\Google_Service_AndroidPublisher::ANDROIDPUBLISHER],
-            $options['p12_key_path']
+            file_get_contents($options['p12_key_path'])
         );
         $this->_client = new \Google_Client();
         $this->_client->setAssertionCredentials($credentials);


### PR DESCRIPTION
* Add load contents of a p12 file 

ServiceAccountValidator accepts option 'p12_key_path' and actual contents of a file should be passed in that option.

* Change readme