### PR TITLE
[iTunes][PurchaseItem] workaround for when expires_date is UNIX timestamp

### DIFF
--- a/src/iTunes/PurchaseItem.php
+++ b/src/iTunes/PurchaseItem.php
@@ -213,6 +213,8 @@ class PurchaseItem
 
     if (array_key_exists('expires_date_ms', $jsonResponse)) {
       $this->_expires_date = Carbon::createFromTimestampUTC(round($jsonResponse['expires_date_ms'] / 1000));
+    } elseif (array_key_exists('expires_date', $jsonResponse) && is_numeric($jsonResponse['expires_date'])) {
+      $this->_expires_date = Carbon::createFromTimestampUTC(round((int)$jsonResponse['expires_date'] / 1000));
     }
 
     if (array_key_exists('cancellation_date_ms', $jsonResponse)) {


### PR DESCRIPTION
We have an iTunes receipt (v. <= 6) that is weird this way ... no idea why. 
Anyway, this fixes it.
I have one more PR coming.