### PR TITLE
Add robrichards/xmlseclibs:^3.0 as possible match

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "guzzlehttp/guzzle": "~6.2",
     "nesbot/carbon": "~1",
     "google/apiclient": "~2.0",
-    "robrichards/xmlseclibs": "^2.0"
+    "robrichards/xmlseclibs": "^2.0|^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8||^5.7"


### PR DESCRIPTION
robrichards/xmlseclibs:3.0 is compatible with 2.0. In 3.0 ext-mcrypt is no longer required.