### PR TITLE
Add exclude-old-transactions support

### DIFF
--- a/src/iTunes/Validator.php
+++ b/src/iTunes/Validator.php
@@ -18,6 +18,13 @@ class Validator
   protected $_endpoint;
 
   /**
+   * Whether to exclude old transactions
+   *
+   * @var bool
+   */
+  protected $_exclude_old_transactions = false;
+
+  /**
    * itunes receipt data, in base64 format
    *
    * @var string|null
@@ -120,6 +127,29 @@ class Validator
   }
 
   /**
+   * get exclude old transactions
+   *
+   * @return bool
+   */
+  public function getExcludeOldTransactions() : bool
+  {
+    return $this->_exclude_old_transactions;
+  }
+
+  /**
+   * set exclude old transactions
+   *
+   * @param bool $exclude
+   * @return Validator
+   */
+  public function setExcludeOldTransactions(bool $exclude) : self
+  {
+    $this->_exclude_old_transactions = $exclude;
+
+    return $this;
+  }
+
+  /**
    * returns the Guzzle client
    *
    * @return HttpClient
@@ -140,7 +170,10 @@ class Validator
    */
   private function encodeRequest()
   {
-    $request = ['receipt-data' => $this->getReceiptData()];
+    $request = [
+        'receipt-data' => $this->getReceiptData(),
+        'exclude-old-transactions' => $this->getExcludeOldTransactions()
+    ];
 
     if (!is_null($this->_sharedSecret)) {
 

--- a/tests/iTunes/ValidatorTest.php
+++ b/tests/iTunes/ValidatorTest.php
@@ -52,4 +52,11 @@ class iTunesValidatorTest extends TestCase
     $this->assertEquals('test-shared-secret', $this->validator->getSharedSecret());
   }
 
+  public function testSetExcludeOldTransactions()
+  {
+    $this->validator->setExcludeOldTransactions(true);
+
+    $this->assertEquals(true, $this->validator->getExcludeOldTransactions());
+  }
+
 }


### PR DESCRIPTION
Simple getter and setter for the `exclude-old-transaction` parameter.

iOS 6 Style receipts ignore this parameter, and it defaults to `false` so **no breaking changes**

Addresses: https://github.com/aporat/store-receipt-validator/issues/64