### PR TITLE
Implement PurchaseItem for latest receipt info

### DIFF
--- a/src/iTunes/PurchaseItem.php
+++ b/src/iTunes/PurchaseItem.php
@@ -3,8 +3,9 @@ namespace ReceiptValidator\iTunes;
 
 use ReceiptValidator\RunTimeException;
 use Carbon\Carbon;
+use ArrayAccess;
 
-class PurchaseItem
+class PurchaseItem implements ArrayAccess
 {
 
   /**
@@ -224,5 +225,51 @@ class PurchaseItem
     }
 
     return $this;
+  }
+
+  /**
+   * Update a response key and reprocess object properties
+   *
+   * @param $key
+   * @param $value
+   *
+   * @throws RunTimeException
+   */
+  public function offsetSet($key, $value)
+  {
+    $this->_response[$key] = $value;
+    $this->parseJsonResponse();
+  }
+
+  /**
+   * Get a response key
+   *
+   * @param $key
+   * @return mixed
+   */
+  public function offsetGet($key)
+  {
+    return $this->_response[$key];
+  }
+
+  /**
+   * Unset a response key
+   *
+   * @param $key
+   */
+  public function offsetUnset($key)
+  {
+    unset($this->_response[$key]);
+  }
+
+  /**
+   * Check if response key exists
+   *
+   * @param $key
+   * @return bool
+   */
+  public function offsetExists($key)
+  {
+    return isset($this->_response[$key]);
   }
 }

--- a/src/iTunes/Response.php
+++ b/src/iTunes/Response.php
@@ -70,7 +70,7 @@ class Response
   /**
    * latest receipt info (needs for auto-renewable subscriptions)
    *
-   * @var array
+   * @var PurchaseItem[]
    */
   protected $_latest_receipt_info;
 
@@ -145,7 +145,7 @@ class Response
   /**
    * Get latest receipt info
    *
-   * @return array
+   * @return PurchaseItem[]
    */
   public function getLatestReceiptInfo()
   {
@@ -221,7 +221,14 @@ class Response
       }
 
       if (array_key_exists('latest_receipt_info', $jsonResponse)) {
-        $this->_latest_receipt_info = $jsonResponse['latest_receipt_info'];
+
+        $this->_latest_receipt_info = array_map(function ($data) {
+          return new PurchaseItem($data);
+        }, $jsonResponse['latest_receipt_info']);
+
+        usort($this->_latest_receipt_info, function (PurchaseItem $a, PurchaseItem $b) {
+          return $b->getPurchaseDate()->timestamp - $a->getPurchaseDate()->timestamp;
+        });
       }
 
       if (array_key_exists('latest_receipt', $jsonResponse)) {


### PR DESCRIPTION
`latest_receipt_info` is pretty much the same as `in_app` (except the contents are the latest regardless of what receipt you send).

`in_app` used your `PurchaseItem` model, but `latest_receipt_info` didn't, so this PR fixes that.

**Backwards compatibility** has been maintained in this PR by implementing `ArrayAccess` on `PurchaseItem` so it shouldn't break existing implementations. 