### PR TITLE
Pending Renewal Class added

### DIFF
--- a/src/iTunes/PendingRenewalInfo.php
+++ b/src/iTunes/PendingRenewalInfo.php
@@ -1,0 +1,259 @@
+<?php
+namespace ReceiptValidator\iTunes;
+
+use ArrayAccess;
+
+class PendingRenewalInfo implements ArrayAccess
+{
+    /*!
+     * Developer friendly field codes
+     * @link https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html
+     */
+
+    // Expiration Intent Codes //
+    /* @var int Customer Cancelled */
+    const EXPIRATION_INTENT_CANCELLED = 1;
+
+    /* @var int Billing Error */
+    const EXPIRATION_INTENT_BILLING_ERROR = 2;
+
+    /* @var int Recent price increase was declined */
+    const EXPIRATION_INTENT_INCREASE_DECLINED = 3;
+
+    /* @var int Product unavailable at time of renewal */
+    const EXPIRATION_INTENT_PRODUCT_UNAVAILABLE = 4;
+
+    /* @var int Unknown */
+    const EXPIRATION_INTENT_UNKNOWN = 5;
+
+
+    // Retry flag codes //
+    /* @var int Still attempting renewal */
+    const RETRY_PERIOD_ACTIVE = 1;
+
+    /* @var int Stopped attempting renewal */
+    const RETRY_PERIOD_INACTIVE = 0;
+
+
+    // Auto renew status codes //
+    /* @var int Subscription will renew */
+    const AUTO_RENEW_ACTIVE = 1;
+
+    /* @var int Customer has turned off renewal */
+    const AUTO_RENEW_INACTIVE = 0;
+
+    /**#@+
+     * Computed status code
+     * @var string
+     */
+    const STATUS_ACTIVE  = 'active';
+    const STATUS_PENDING = 'pending';
+    const STATUS_EXPIRED = 'expired';
+    /**#@-*/
+
+    /**
+     * Pending renewal info
+     * @var array
+     */
+    protected $_raw = [];
+
+    /**
+     * Product ID
+     * @var string|null
+     */
+    protected $_product_id;
+
+    /**
+     * Auto Renew Product ID
+     * @var string|null
+     */
+    protected $_auto_renew_product_id;
+
+    /**
+     * Original Transation ID
+     * @var string|null
+     */
+    protected $_original_transaction_id;
+
+    /**
+     * Expiration Intent Code
+     * @var int|null
+     */
+    protected $_expiration_intent;
+
+    /**
+     * Is In Billing Retry Period Code
+     * @var int|null
+     */
+    protected $_is_in_billing_retry_period;
+
+    /**
+     * Auto Renew Status Code
+     * @var int|null
+     */
+    protected $_auto_renew_status;
+
+    public function __construct(array $rawData)
+    {
+        $this->_raw = $rawData;
+        $this->hydrateFromRawData();
+    }
+
+    /**
+     * Hydrate the model from the provided data
+     *
+     * @return PendingRenewalInfo
+     */
+    protected function hydrateFromRawData() : self
+    {
+        // Always available
+        $this->_product_id = $this->_raw['product_id'] ?? null;
+        $this->_auto_renew_product_id = $this->_raw['auto_renew_product_id'] ?? null;
+        $this->_auto_renew_status = isset($this->_raw['auto_renew_status']) ? (int) $this->_raw['auto_renew_status'] : null;
+
+        // Also always available but not in existing fixture, so will assume optional for backwards compatibility
+        $this->_original_transaction_id = $this->_raw['original_transaction_id'] ?? null;
+
+        // Optionals
+        $this->_expiration_intent = isset($this->_raw['expiration_intent']) ? (int) $this->_raw['expiration_intent'] : null;
+        $this->_is_in_billing_retry_period = isset($this->_raw['is_in_billing_retry_period']) ? (int) $this->_raw['is_in_billing_retry_period'] : null;
+
+        return $this;
+    }
+
+    /*****************************************
+     * GETTERS
+     *****************************************/
+
+    /**
+     * Product ID
+     * @return string|null
+     */
+    public function getProductId()
+    {
+        return $this->_product_id;
+    }
+
+    /**
+     * Auto Renew Product ID
+     * @return string|null
+     */
+    public function getAutoRenewProductId()
+    {
+        return $this->_auto_renew_product_id;
+    }
+
+    /**
+     * Auto Renew Status Code
+     * @return int|null
+     */
+    public function getAutoRenewStatus()
+    {
+        return $this->_auto_renew_status;
+    }
+
+    /**
+     * Original Transaction ID
+     * @return string|null
+     */
+    public function getOriginalTransactionId()
+    {
+        return $this->_original_transaction_id;
+    }
+
+    /**
+     * Expiration Intent Code
+     * @return int|null
+     */
+    public function getExpirationIntent()
+    {
+        return $this->_expiration_intent;
+    }
+
+    /**
+     * Is In Billing Retry Period Code
+     * @return int|null
+     */
+    public function getIsInBillingRetryPeriod()
+    {
+        return $this->_is_in_billing_retry_period;
+    }
+
+    /*****************************************
+     * Convenience methods
+     *****************************************/
+
+    /**
+     * Status of Pending Renewal
+     *
+     * This is a computed property that assumes a particular status based on
+     * contextual information.
+     *
+     * @return string|null
+     */
+    public function getStatus()
+    {
+        // Active when no expiration intent
+        if (null === $this->_expiration_intent) {
+            return $this::STATUS_ACTIVE;
+        }
+
+        // Pending when retrying
+        if ($this::RETRY_PERIOD_ACTIVE === $this->_is_in_billing_retry_period) {
+            return $this::STATUS_PENDING;
+        }
+
+        // Expired when not retrying
+        if ($this::RETRY_PERIOD_INACTIVE === $this->_is_in_billing_retry_period) {
+            return $this::STATUS_EXPIRED;
+        }
+
+        return null;
+    }
+
+    /**
+     * Update a key and reprocess object properties
+     *
+     * @param $key
+     * @param $value
+     *
+     * @throws RunTimeException
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->_raw[$key] = $value;
+        $this->hydrateFromRawData();
+    }
+
+    /**
+     * Get a value
+     *
+     * @param $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->_raw[$key];
+    }
+
+    /**
+     * Unset a key
+     *
+     * @param $key
+     */
+    public function offsetUnset($key)
+    {
+        unset($this->_raw[$key]);
+    }
+
+    /**
+     * Check if key exists
+     *
+     * @param $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return isset($this->_raw[$key]);
+    }
+}

--- a/src/iTunes/Response.php
+++ b/src/iTunes/Response.php
@@ -82,7 +82,7 @@ class Response
 
   /**
    * pending renewal info
-   * @var string
+   * @var PendingRenewalInfo[]
    */
   protected $_pending_renewal_info;
 
@@ -175,7 +175,7 @@ class Response
   /**
    * Get the pending renewal info
    *
-   * @return string
+   * @return PendingRenewalInfo[]
    */
   public function getPendingRenewalInfo()
   {
@@ -229,7 +229,9 @@ class Response
       }
 
       if (array_key_exists('pending_renewal_info', $jsonResponse)) {
-        $this->_pending_renewal_info = $jsonResponse['pending_renewal_info'];
+        $this->_pending_renewal_info = array_map(function ($data) {
+            return new PendingRenewalInfo($data);
+        }, $jsonResponse['pending_renewal_info']);
       }
     } elseif (array_key_exists('receipt', $jsonResponse)) {
 

--- a/tests/iTunes/PendingRenewalInfoTest.php
+++ b/tests/iTunes/PendingRenewalInfoTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use PHPUnit\Framework\Error\Notice;
+use ReceiptValidator\iTunes\PendingRenewalInfo;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\IsType;
+
+/**
+ * @group library
+ */
+class iTunesPendingRenewalInfoTest extends TestCase
+{
+
+  public function testEmptyConstructor()
+  {
+    $this->expectException('TypeError');
+
+    new PendingRenewalInfo();
+  }
+
+  public function testInvalidTypeToContructor()
+  {
+    $this->expectException('TypeError');
+
+    new PendingRenewalInfo('invalid');
+  }
+
+  public function testFullObjectHydration()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'original_transaction_id' => 'Transaction_1',
+        'auto_renew_status' => '0',
+        'is_in_billing_retry_period' => '1',
+        'expiration_intent' => '1'
+    ];
+    $info = new PendingRenewalInfo($raw);
+
+    $this->assertInternalType(IsType::TYPE_STRING, $info->getAutoRenewProductId());
+    $this->assertEquals($raw['auto_renew_product_id'], $info->getAutoRenewProductId());
+
+    $this->assertInternalType(IsType::TYPE_STRING, $info->getProductId());
+    $this->assertEquals($raw['product_id'], $info->getProductId());
+
+    $this->assertInternalType(IsType::TYPE_STRING, $info->getOriginalTransactionId());
+    $this->assertEquals($raw['original_transaction_id'], $info->getOriginalTransactionId());
+
+    $this->assertInternalType(IsType::TYPE_INT, $info->getAutoRenewStatus());
+    $this->assertEquals($raw['auto_renew_status'], $info->getAutoRenewStatus());
+
+    $this->assertInternalType(IsType::TYPE_INT, $info->getIsInBillingRetryPeriod());
+    $this->assertEquals($raw['is_in_billing_retry_period'], $info->getIsInBillingRetryPeriod());
+
+    $this->assertInternalType(IsType::TYPE_INT, $info->getExpirationIntent());
+    $this->assertEquals($raw['expiration_intent'], $info->getExpirationIntent());
+  }
+
+  public function testPartialObjectHydration()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'auto_renew_status' => '1'
+    ];
+    $info = new PendingRenewalInfo($raw);
+
+    $this->assertInternalType(IsType::TYPE_STRING, $info->getAutoRenewProductId());
+    $this->assertEquals($raw['auto_renew_product_id'], $info->getAutoRenewProductId());
+
+    $this->assertInternalType(IsType::TYPE_STRING, $info->getProductId());
+    $this->assertEquals($raw['product_id'], $info->getProductId());
+
+    $this->assertInternalType(IsType::TYPE_INT, $info->getAutoRenewStatus());
+    $this->assertEquals($raw['auto_renew_status'], $info->getAutoRenewStatus());
+
+    $this->assertNull($info->getOriginalTransactionId());
+    $this->assertNull($info->getIsInBillingRetryPeriod());
+    $this->assertNull($info->getExpirationIntent());
+  }
+
+  public function testComputedUnknownStatus()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'original_transaction_id' => 'Transaction_1',
+        'auto_renew_status' => '0',
+        'expiration_intent' => '1'
+    ];
+    $info = new PendingRenewalInfo($raw);
+    $this->assertNull($info->getStatus());
+  }
+
+  public function testComputedActiveStatus()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'original_transaction_id' => 'Transaction_1',
+        'auto_renew_status' => '1'
+    ];
+    $info = new PendingRenewalInfo($raw);
+    $this->assertEquals(PendingRenewalInfo::STATUS_ACTIVE, $info->getStatus());
+  }
+
+  public function testComputedPendingStatus()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'original_transaction_id' => 'Transaction_1',
+        'auto_renew_status' => '1',
+        'expiration_intent' => '5',
+        'is_in_billing_retry_period' => '1'
+    ];
+    $info = new PendingRenewalInfo($raw);
+    $this->assertEquals(PendingRenewalInfo::STATUS_PENDING, $info->getStatus());
+  }
+
+  public function testComputedExpiredStatus()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'original_transaction_id' => 'Transaction_1',
+        'auto_renew_status' => '1',
+        'expiration_intent' => '5',
+        'is_in_billing_retry_period' => '0'
+    ];
+    $info = new PendingRenewalInfo($raw);
+    $this->assertEquals(PendingRenewalInfo::STATUS_EXPIRED, $info->getStatus());
+  }
+
+  public function testBehavesLikeArray()
+  {
+    $raw = [
+        'auto_renew_product_id' => 'Test_Subscription_1',
+        'product_id' => 'Test_Subscription_2',
+        'original_transaction_id' => 'Transaction_1',
+        'auto_renew_status' => '0',
+        'is_in_billing_retry_period' => '1',
+        'expiration_intent' => '1'
+    ];
+    $info = new PendingRenewalInfo($raw);
+
+    // Get existing
+    $this->assertEquals('Test_Subscription_1', $info['auto_renew_product_id']);
+
+    // Get non-existing
+    $this->expectException(Notice::class);
+    $info['undefined_value'];
+
+    // Set existing
+    $info['product_id'] = 'new_product_id';
+    $this->assertEquals('new_product_id', $info['product_id']);
+    $this->assertEquals('new_product_id', $info->getProductId());
+
+    // Set new
+    $info['undefined_value'] = 'test';
+    $this->assertEquals('test', $info['undefined_value']);
+
+    // Exists
+    $this->assertEquals(true, $info['product_id']);
+    $this->assertEquals(false, $info['another_undefined_value']);
+
+    // Unset
+    $info['unset_test'] = 'tmp';
+    $this->assertEquals('tmp', $info['unset_test']);
+    unset($info['unset_test']);
+    $this->expectException(Notice::class);
+    $info['unset_test'];
+  }
+}

--- a/tests/iTunes/ResponseTest.php
+++ b/tests/iTunes/ResponseTest.php
@@ -59,6 +59,6 @@ class iTunesResponseTest extends TestCase
     $this->assertEquals($jsonResponseArray['receipt']['bundle_id'], $response->getBundleId(), 'receipt bundle id must match');
 
     $this->assertInternalType(IsType::TYPE_ARRAY, $response->getPendingRenewalInfo());
-    $this->assertEquals($jsonResponseArray['pending_renewal_info'], $response->getPendingRenewalInfo(), 'pending renewal info must match');
+    $this->assertContainsOnly('ReceiptValidator\iTunes\PendingRenewalInfo', $response->getPendingRenewalInfo());
   }
 }


### PR DESCRIPTION
Adds a `PendingRenewalInfo` object to model the data in that part of the receipt, much like how the existing `PurchaseItem` class works.

Backwards compatibility has been maintained by implementing `ArrayAccess` on the class. 