### PR TITLE
Add possibility to get promotional offer id.

### DIFF
--- a/src/iTunes/PurchaseItem.php
+++ b/src/iTunes/PurchaseItem.php
@@ -86,7 +86,7 @@ class PurchaseItem implements ArrayAccess
     protected $is_in_intro_offer_period;
 
     /**
-     * When a subscriber redeems an offer, there is a promotional offer ID
+     * When a subscriber redeems an offer, there is a promotional offer ID.
      *
      * @var string|null
      */
@@ -115,9 +115,9 @@ class PurchaseItem implements ArrayAccess
     /**
      * Parse Data from JSON Response.
      *
-     * @return $this
      * @throws RunTimeException
      *
+     * @return $this
      */
     public function parseData(): self
     {
@@ -126,7 +126,7 @@ class PurchaseItem implements ArrayAccess
         }
 
         if (array_key_exists('quantity', $this->raw_data)) {
-            $this->quantity = (int)$this->raw_data['quantity'];
+            $this->quantity = (int) $this->raw_data['quantity'];
         }
 
         if (array_key_exists('transaction_id', $this->raw_data)) {
@@ -162,27 +162,27 @@ class PurchaseItem implements ArrayAccess
 
         if (array_key_exists('purchase_date_ms', $this->raw_data)) {
             $this->purchase_date = Carbon::createFromTimestampUTC(
-                (int)round($this->raw_data['purchase_date_ms'] / 1000)
+                (int) round($this->raw_data['purchase_date_ms'] / 1000)
             );
         }
 
         if (array_key_exists('original_purchase_date_ms', $this->raw_data)) {
             $this->original_purchase_date = Carbon::createFromTimestampUTC(
-                (int)round($this->raw_data['original_purchase_date_ms'] / 1000)
+                (int) round($this->raw_data['original_purchase_date_ms'] / 1000)
             );
         }
 
         if (array_key_exists('expires_date_ms', $this->raw_data)) {
-            $this->expires_date = Carbon::createFromTimestampUTC((int)round($this->raw_data['expires_date_ms'] / 1000));
+            $this->expires_date = Carbon::createFromTimestampUTC((int) round($this->raw_data['expires_date_ms'] / 1000));
         } elseif (array_key_exists('expires_date', $this->raw_data) && is_numeric($this->raw_data['expires_date'])) {
             $this->expires_date = Carbon::createFromTimestampUTC(
-                (int)round((int)$this->raw_data['expires_date'] / 1000)
+                (int) round((int) $this->raw_data['expires_date'] / 1000)
             );
         }
 
         if (array_key_exists('cancellation_date_ms', $this->raw_data)) {
             $this->cancellation_date = Carbon::createFromTimestampUTC(
-                (int)round($this->raw_data['cancellation_date_ms'] / 1000)
+                (int) round($this->raw_data['cancellation_date_ms'] / 1000)
             );
         }
 

--- a/src/iTunes/PurchaseItem.php
+++ b/src/iTunes/PurchaseItem.php
@@ -76,21 +76,28 @@ class PurchaseItem implements ArrayAccess
      *
      * @var bool|null
      */
-    protected $is_trial_period = null;
+    protected $is_trial_period;
 
     /**
      * For an auto-renewable subscription, whether or not it is in the introductory price period.
      *
      * @var bool|null
      */
-    protected $is_in_intro_offer_period = null;
+    protected $is_in_intro_offer_period;
+
+    /**
+     * When a subscriber redeems an offer, there is a promotional offer ID
+     *
+     * @var string|null
+     */
+    protected $promotional_offer_id;
 
     /**
      * purchase item info.
      *
      * @var array|null
      */
-    protected $raw_data = null;
+    protected $raw_data;
 
     /**
      * PurchaseItem constructor.
@@ -136,6 +143,10 @@ class PurchaseItem implements ArrayAccess
 
         if (array_key_exists('web_order_line_item_id', $this->raw_data)) {
             $this->web_order_line_item_id = $this->raw_data['web_order_line_item_id'];
+        }
+
+        if (array_key_exists('promotional_offer_id', $this->raw_data)) {
+            $this->promotional_offer_id = $this->raw_data['promotional_offer_id'];
         }
 
         if (array_key_exists('is_trial_period', $this->raw_data)) {
@@ -208,6 +219,14 @@ class PurchaseItem implements ArrayAccess
     public function isInIntroOfferPeriod(): ?bool
     {
         return $this->is_in_intro_offer_period;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPromotionalOfferId(): ?string
+    {
+        return $this->promotional_offer_id;
     }
 
     /**

--- a/tests/iTunes/PurchaseItemTest.php
+++ b/tests/iTunes/PurchaseItemTest.php
@@ -164,4 +164,32 @@ class PurchaseItemTest extends TestCase
             $info->getWebOrderLineItemId()
         );
     }
+
+    public function testPurchaseDataWithPromotionalOfferId(): void
+    {
+        $raw_data = [
+            'quantity' => '1',
+            'product_id' => 'product.subscription',
+            'transaction_id' => '720000261479083',
+            'original_transaction_id' => '720000261479083',
+            'purchase_date' => '2018-06-14 05:41:29 Etc/GMT',
+            'purchase_date_ms' => 1528954889000,
+            'purchase_date_pst' => '2018-06-13 22:41:29 America/Los_Angeles',
+            'original_purchase_date' => '2018-06-14 05:41:31 Etc/GMT',
+            'original_purchase_date_ms' => 1528954891000,
+            'original_purchase_date_pst' => '2018-06-13 22:41:31 America/Los_Angeles',
+            'expires_date' => '2018-06-21 05:41:29 Etc/GMT',
+            'expires_date_ms' => 1529559689000,
+            'expires_date_pst' => '2018-06-20 22:41:29 America/Los_Angeles',
+            'web_order_line_item_id' => null,
+            'is_trial_period' => true,
+            'is_in_intro_offer_period' => false,
+            'promotional_offer_id' => 'PROMOOFFER'
+        ];
+
+        $info = new PurchaseItem($raw_data);
+
+        $this->assertNotNull($info->getPromotionalOfferId());
+        $this->assertEquals($raw_data['promotional_offer_id'], $info->getPromotionalOfferId());
+    }
 }

--- a/tests/iTunes/PurchaseItemTest.php
+++ b/tests/iTunes/PurchaseItemTest.php
@@ -25,17 +25,17 @@ class PurchaseItemTest extends TestCase
     public function testPurchaseData(): void
     {
         $raw_data = [
-            'is_trial_period' => 'false',
-            'original_purchase_date' => '2015-05-24 01:06:58 Etc\/GMT',
-            'original_purchase_date_ms' => 1432429618000,
+            'is_trial_period'            => 'false',
+            'original_purchase_date'     => '2015-05-24 01:06:58 Etc\/GMT',
+            'original_purchase_date_ms'  => 1432429618000,
             'original_purchase_date_pst' => '2015-05-23 18:06:58 America\/Los_Angeles',
-            'original_transaction_id' => 1000000156455961,
-            'product_id' => 'myapp.1',
-            'purchase_date' => '2015-05-24 01:06:58 Etc\/GMT',
-            'purchase_date_ms' => 1432429618000,
-            'purchase_date_pst' => '2015-05-23 18:06:58 America\/Los_Angeles',
-            'quantity' => 1,
-            'transaction_id' => 1000000156455961,
+            'original_transaction_id'    => 1000000156455961,
+            'product_id'                 => 'myapp.1',
+            'purchase_date'              => '2015-05-24 01:06:58 Etc\/GMT',
+            'purchase_date_ms'           => 1432429618000,
+            'purchase_date_pst'          => '2015-05-23 18:06:58 America\/Los_Angeles',
+            'quantity'                   => 1,
+            'transaction_id'             => 1000000156455961,
         ];
 
         $info = new PurchaseItem($raw_data);
@@ -74,22 +74,22 @@ class PurchaseItemTest extends TestCase
     public function testSubscriptionPurchaseData(): void
     {
         $raw_data = [
-            'quantity' => '1',
-            'product_id' => 'product.subscription',
-            'transaction_id' => '720000261479083',
-            'original_transaction_id' => '720000261479083',
-            'purchase_date' => '2018-06-14 05:41:29 Etc/GMT',
-            'purchase_date_ms' => 1528954889000,
-            'purchase_date_pst' => '2018-06-13 22:41:29 America/Los_Angeles',
-            'original_purchase_date' => '2018-06-14 05:41:31 Etc/GMT',
-            'original_purchase_date_ms' => 1528954891000,
+            'quantity'                   => '1',
+            'product_id'                 => 'product.subscription',
+            'transaction_id'             => '720000261479083',
+            'original_transaction_id'    => '720000261479083',
+            'purchase_date'              => '2018-06-14 05:41:29 Etc/GMT',
+            'purchase_date_ms'           => 1528954889000,
+            'purchase_date_pst'          => '2018-06-13 22:41:29 America/Los_Angeles',
+            'original_purchase_date'     => '2018-06-14 05:41:31 Etc/GMT',
+            'original_purchase_date_ms'  => 1528954891000,
             'original_purchase_date_pst' => '2018-06-13 22:41:31 America/Los_Angeles',
-            'expires_date' => '2018-06-21 05:41:29 Etc/GMT',
-            'expires_date_ms' => 1529559689000,
-            'expires_date_pst' => '2018-06-20 22:41:29 America/Los_Angeles',
-            'web_order_line_item_id' => 720000062004133,
-            'is_trial_period' => true,
-            'is_in_intro_offer_period' => false,
+            'expires_date'               => '2018-06-21 05:41:29 Etc/GMT',
+            'expires_date_ms'            => 1529559689000,
+            'expires_date_pst'           => '2018-06-20 22:41:29 America/Los_Angeles',
+            'web_order_line_item_id'     => 720000062004133,
+            'is_trial_period'            => true,
+            'is_in_intro_offer_period'   => false,
         ];
 
         $info = new PurchaseItem($raw_data);
@@ -121,22 +121,22 @@ class PurchaseItemTest extends TestCase
     public function testPurchaseDataWithoutWebOrderLineItemId(): void
     {
         $raw_data = [
-            'quantity' => '1',
-            'product_id' => 'product.subscription',
-            'transaction_id' => '720000261479083',
-            'original_transaction_id' => '720000261479083',
-            'purchase_date' => '2018-06-14 05:41:29 Etc/GMT',
-            'purchase_date_ms' => 1528954889000,
-            'purchase_date_pst' => '2018-06-13 22:41:29 America/Los_Angeles',
-            'original_purchase_date' => '2018-06-14 05:41:31 Etc/GMT',
-            'original_purchase_date_ms' => 1528954891000,
+            'quantity'                   => '1',
+            'product_id'                 => 'product.subscription',
+            'transaction_id'             => '720000261479083',
+            'original_transaction_id'    => '720000261479083',
+            'purchase_date'              => '2018-06-14 05:41:29 Etc/GMT',
+            'purchase_date_ms'           => 1528954889000,
+            'purchase_date_pst'          => '2018-06-13 22:41:29 America/Los_Angeles',
+            'original_purchase_date'     => '2018-06-14 05:41:31 Etc/GMT',
+            'original_purchase_date_ms'  => 1528954891000,
             'original_purchase_date_pst' => '2018-06-13 22:41:31 America/Los_Angeles',
-            'expires_date' => '2018-06-21 05:41:29 Etc/GMT',
-            'expires_date_ms' => 1529559689000,
-            'expires_date_pst' => '2018-06-20 22:41:29 America/Los_Angeles',
-            'web_order_line_item_id' => null,
-            'is_trial_period' => true,
-            'is_in_intro_offer_period' => false,
+            'expires_date'               => '2018-06-21 05:41:29 Etc/GMT',
+            'expires_date_ms'            => 1529559689000,
+            'expires_date_pst'           => '2018-06-20 22:41:29 America/Los_Angeles',
+            'web_order_line_item_id'     => null,
+            'is_trial_period'            => true,
+            'is_in_intro_offer_period'   => false,
         ];
 
         $info = new PurchaseItem($raw_data);
@@ -168,23 +168,23 @@ class PurchaseItemTest extends TestCase
     public function testPurchaseDataWithPromotionalOfferId(): void
     {
         $raw_data = [
-            'quantity' => '1',
-            'product_id' => 'product.subscription',
-            'transaction_id' => '720000261479083',
-            'original_transaction_id' => '720000261479083',
-            'purchase_date' => '2018-06-14 05:41:29 Etc/GMT',
-            'purchase_date_ms' => 1528954889000,
-            'purchase_date_pst' => '2018-06-13 22:41:29 America/Los_Angeles',
-            'original_purchase_date' => '2018-06-14 05:41:31 Etc/GMT',
-            'original_purchase_date_ms' => 1528954891000,
+            'quantity'                   => '1',
+            'product_id'                 => 'product.subscription',
+            'transaction_id'             => '720000261479083',
+            'original_transaction_id'    => '720000261479083',
+            'purchase_date'              => '2018-06-14 05:41:29 Etc/GMT',
+            'purchase_date_ms'           => 1528954889000,
+            'purchase_date_pst'          => '2018-06-13 22:41:29 America/Los_Angeles',
+            'original_purchase_date'     => '2018-06-14 05:41:31 Etc/GMT',
+            'original_purchase_date_ms'  => 1528954891000,
             'original_purchase_date_pst' => '2018-06-13 22:41:31 America/Los_Angeles',
-            'expires_date' => '2018-06-21 05:41:29 Etc/GMT',
-            'expires_date_ms' => 1529559689000,
-            'expires_date_pst' => '2018-06-20 22:41:29 America/Los_Angeles',
-            'web_order_line_item_id' => null,
-            'is_trial_period' => true,
-            'is_in_intro_offer_period' => false,
-            'promotional_offer_id' => 'PROMOOFFER'
+            'expires_date'               => '2018-06-21 05:41:29 Etc/GMT',
+            'expires_date_ms'            => 1529559689000,
+            'expires_date_pst'           => '2018-06-20 22:41:29 America/Los_Angeles',
+            'web_order_line_item_id'     => null,
+            'is_trial_period'            => true,
+            'is_in_intro_offer_period'   => false,
+            'promotional_offer_id'       => 'PROMOOFFER',
         ];
 
         $info = new PurchaseItem($raw_data);


### PR DESCRIPTION
Apple has added support for promotinal offers: https://developer.apple.com/documentation/storekit/in-app_purchase/implementing_subscription_offers_in_your_app

This pull request adds possibility to get promotional offer id for transaction