### PR TITLE
Set TLS version 1.2 on cURL POST request

### DIFF
--- a/src/iTunes/Validator.php
+++ b/src/iTunes/Validator.php
@@ -258,7 +258,7 @@ class Validator
     {
         $baseUri = (string)$client->getConfig('base_uri');
 
-        $httpResponse = $client->request('POST', null, ['body' => $this->prepareRequestData()]);
+        $httpResponse = $client->request('POST', null, ['body' => $this->prepareRequestData(), 'curl' => [CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2]]);
 
         if ($httpResponse->getStatusCode() !== 200) {
             throw new RunTimeException('Unable to get response from itunes server');


### PR DESCRIPTION
This edit prevents the following error during the cURL POST request:
`Apple validation request failed: cURL error 35: Unknown SSL protocol error in connection to sandbox.itunes.apple.com:443  (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)`