### PR TITLE
Swappable guzzle client

### DIFF
--- a/src/iTunes/Validator.php
+++ b/src/iTunes/Validator.php
@@ -57,17 +57,22 @@ class Validator
     /**
      * Validator constructor.
      *
-     * @param string $endpoint
+     * @param string     $endpoint
+     * @param HttpClient $client
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(string $endpoint = self::ENDPOINT_PRODUCTION)
+    public function __construct(string $endpoint = self::ENDPOINT_PRODUCTION, HttpClient $client = null)
     {
         if ($endpoint !== self::ENDPOINT_PRODUCTION && $endpoint !== self::ENDPOINT_SANDBOX) {
             throw new \InvalidArgumentException("Invalid endpoint '{$endpoint}'");
         }
 
         $this->endpoint = $endpoint;
+
+        $this->client = $client
+            ? new $client($this->getClientConfig())
+            : new HttpClient($this->getClientConfig());
     }
 
     /**


### PR DESCRIPTION
This PR introduces a way to swap the guzzle client.

This can be particularly useful if, for example, a dev wants to use a different class that extends the `GuzzleHttp\Client`.

My personal use-case in my Laravel application was that I wanted to swap the client when running Tests with a custom class that extends the `GuzzleHttp\Client` and has some special snapshotting functionality in it.

Example from the codebase located in the `app/Providers/AppServiceProvider.php`

```php
$this->app->bind(iTunesValidator::class, function () {
    if ($this->app->runningUnitTests()) {
        return new iTunesValidator(
            iTunesValidator::ENDPOINT_SANDBOX,
            new GuzzleSnapshotClient()
        );
    }

    return new iTunesValidator(
        iTunesValidator::ENDPOINT_PRODUCTION,
    );
});
```

This is **NOT** a breaking change because the newly introduced `__construct` argument has a default fallback value - `null` if the client is not provided when `iTunesValidator` is instantiated.