### PR TITLE
Bump GuzzleHttp without conflict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
@@ -61,7 +60,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "Apache-2.0"
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2.5",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
         "nesbot/carbon": "^1.0|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.1",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0",
         "nesbot/carbon": "^1.0|^2.0",
         "google/apiclient": "^2.0",
         "robrichards/xmlseclibs": "^3.0.4"


### PR DESCRIPTION
In order to be used with the latest version of Laravel, `guzzlehttp/guzzle` has to be version 7.0+. I therefore bumped the version and reran the tests to ensure nothing failed.