### PR TITLE
Fix issue where Guzzle client would not recognise full base_uri due to missing backslash

### DIFF
--- a/src/Amazon/Validator.php
+++ b/src/Amazon/Validator.php
@@ -8,8 +8,8 @@ use ReceiptValidator\RunTimeException as RunTimeException;
 
 class Validator
 {
-    const ENDPOINT_SANDBOX = 'http://localhost:8080/RVSSandbox';
-    const ENDPOINT_PRODUCTION = 'https://appstore-sdk.amazon.com/version/1.0/verifyReceiptId';
+    const ENDPOINT_SANDBOX = 'http://localhost:8080/RVSSandbox/';
+    const ENDPOINT_PRODUCTION = 'https://appstore-sdk.amazon.com/version/1.0/verifyReceiptId/';
 
     /**
      * endpoint url.
@@ -153,7 +153,7 @@ class Validator
         try {
             $httpResponse = $this->getClient()->request(
                 'GET',
-                sprintf('/developer/%s/user/%s/receiptId/%s', $this->developerSecret, $this->userId, $this->receiptId)
+                sprintf('developer/%s/user/%s/receiptId/%s', $this->developerSecret, $this->userId, $this->receiptId)
             );
 
             return new Response($httpResponse->getStatusCode(), json_decode($httpResponse->getBody(), true));


### PR DESCRIPTION
Hello, this commit https://github.com/aporat/store-receipt-validator/commit/6641921d392ab8b0f3e44786aea0e1c3596dbf00 breaks communication with Amazon's API.

As documented here: https://github.com/guzzle/guzzle/issues/1254 and also in the section about base_uri here: http://docs.guzzlephp.org/en/stable/quickstart.html, the base_uri passed when creating a new Guzzle client must end in a backslash for it to take any notice of the full path.

What was happening was that it was when verifying an Amazon receipt, it was making requests to http://appstore-sdk.amazon.com/developer/%s/user/%s/receiptId/%s, rather than http://appstore-sdk.amazon.com/version/1.0/verifyReceiptId/developer/%s/user/%s/receiptId/%s like it should be. Meaning every request was coming back as a 404!