### PR TITLE
PHP 8.1 fixes for deprecations 

### DIFF
--- a/src/iTunes/PendingRenewalInfo.php
+++ b/src/iTunes/PendingRenewalInfo.php
@@ -281,6 +281,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @throws RunTimeException
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->raw_data[$key] = $value;
@@ -294,6 +295,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->raw_data[$key];
@@ -304,6 +306,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @param $key
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->raw_data[$key]);
@@ -316,6 +319,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($key): bool
     {
         return isset($this->raw_data[$key]);

--- a/src/iTunes/PendingRenewalInfo.php
+++ b/src/iTunes/PendingRenewalInfo.php
@@ -281,7 +281,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @throws RunTimeException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->raw_data[$key] = $value;
@@ -295,7 +295,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->raw_data[$key];
@@ -306,7 +306,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @param $key
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->raw_data[$key]);
@@ -319,7 +319,7 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($key): bool
     {
         return isset($this->raw_data[$key]);

--- a/src/iTunes/PurchaseItem.php
+++ b/src/iTunes/PurchaseItem.php
@@ -301,6 +301,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @throws RunTimeException
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->raw_data[$key] = $value;
@@ -314,6 +315,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->raw_data[$key];
@@ -324,6 +326,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @param $key
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->raw_data[$key]);
@@ -336,6 +339,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->raw_data[$key]);

--- a/src/iTunes/PurchaseItem.php
+++ b/src/iTunes/PurchaseItem.php
@@ -301,7 +301,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @throws RunTimeException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->raw_data[$key] = $value;
@@ -315,7 +315,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->raw_data[$key];
@@ -326,7 +326,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @param $key
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->raw_data[$key]);
@@ -339,7 +339,7 @@ class PurchaseItem implements ArrayAccess
      *
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->raw_data[$key]);


### PR DESCRIPTION
use #[\ReturnTypeWillChange] to suppress php 8.1 deprecations when a class implements ArrayAccess