### PR TITLE
Prevent undefined index error

### DIFF
--- a/src/iTunes/PendingRenewalInfo.php
+++ b/src/iTunes/PendingRenewalInfo.php
@@ -298,7 +298,7 @@ class PendingRenewalInfo implements ArrayAccess
     #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
-        return $this->raw_data[$key];
+        return $this->raw_data[$key] ?? null;
     }
 
     /**


### PR DESCRIPTION
Prevent error when use \ReceiptValidator\iTunes\PendingRenewalInfo::offsetGet()

`PHP Notice:  Undefined index: is_in_billing_retry_period in /var/www/html/aporat/store-receipt-validator/src/iTunes/PendingRenewalInfo.php on line 299`