### PR TITLE
Add function getExternalAccountId

### DIFF
--- a/src/GooglePlay/SubscriptionResponse.php
+++ b/src/GooglePlay/SubscriptionResponse.php
@@ -95,4 +95,12 @@ class SubscriptionResponse extends AbstractResponse
     {
         return $this->response->expiryTimeMillis;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getExternalAccountId()
+    {
+        return $this->response->getExternalAccountId();
+    }
 }


### PR DESCRIPTION
Add a function `getExternalAccountId()` to `SubscriptionResponse` to be able to quickly check if the subscription has been attributed to the correct user.