### PR TITLE
Fix json_encode deprecation warning

### DIFF
--- a/src/GooglePlay/PurchaseResponse.php
+++ b/src/GooglePlay/PurchaseResponse.php
@@ -19,7 +19,9 @@ class PurchaseResponse extends AbstractResponse
     public function __construct($response)
     {
         parent::__construct($response);
-        $this->developerPayload = json_decode($this->response->developerPayload, true);
+        if (isset($this->response->developerPayload)) {
+            $this->developerPayload = json_decode($this->response->developerPayload, true);
+        }
     }
 
     /**


### PR DESCRIPTION
Since `developerPayload` is not mandatory `json_encode()` will throw a deprecation warning in PHP8  when `developerPayload` is null.