### PR TITLE
Allow installation of nesbot/carbon v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.3|^8.0.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "nesbot/carbon": "^1.0|^2.0",
+        "nesbot/carbon": "^1.0|^2.0|^3.0",
         "google/apiclient": "^2.10",
         "google/apiclient-services": "~0.249",
         "robrichards/xmlseclibs": "^3.0.4"


### PR DESCRIPTION
Carbon v3 was released yesterday.

This change also allows installation on projects using Symfony 7 since carbon has a couple of Symfony dependencies.

Please tag a new release once this has been merged.