### PR TITLE
Fix must not be accessed before initialization

### DIFF
--- a/src/iTunes/PendingRenewalInfo.php
+++ b/src/iTunes/PendingRenewalInfo.php
@@ -95,14 +95,14 @@ class PendingRenewalInfo implements ArrayAccess
      *
      * @var Carbon|null
      */
-    protected ?Carbon $grace_period_expires_date;
+    protected ?Carbon $grace_period_expires_date = null;
 
     /**
      * Is In Billing Retry Period Code.
      *
      * @var int|null
      */
-    protected ?int $is_in_billing_retry_period;
+    protected ?int $is_in_billing_retry_period = null;
 
     /**
      * Pending renewal info.


### PR DESCRIPTION
Those property may not be present in parse data so they need a default value since calling the get will fail if not initialize