### PR TITLE
Fix unnecessary concatenation

### DIFF
--- a/src/AppleAppStore/Validator.php
+++ b/src/AppleAppStore/Validator.php
@@ -144,7 +144,7 @@ class Validator extends AbstractValidator
         $token = $this->generateToken();
 
         try {
-            $httpResponse = $this->getClient($endpoint)->request($method, $endpoint . $uri, [
+            $httpResponse = $this->getClient($endpoint)->request($method, $uri, [
                 'headers' => [
                     'Authorization' => "Bearer {$token->toString()}",
                 ],


### PR DESCRIPTION
Hi, noticed that endpoint concatenation is unnecessary here, since the endpoint is passed in the getClient method, so it is enough to pass only $uri