### PR TITLE
Add App Store Server API endpoints for subscriptions and refunds

### DIFF
--- a/src/AppleAppStore/ConsumptionRequest.php
+++ b/src/AppleAppStore/ConsumptionRequest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\AppleAppStore;
+
+/**
+ * Request body for the Send Consumption Information endpoint.
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/send-consumption-information
+ */
+final class ConsumptionRequest
+{
+    /**
+     * A Boolean value that indicates whether the customer consented to provide
+     * consumption data to the App Store.
+     */
+    public bool $customerConsented;
+
+    /**
+     * A Boolean value that indicates whether you provided, prior to its purchase,
+     * a free sample or trial of the content, or information about its functionality.
+     */
+    public bool $sampleContentProvided;
+
+    /**
+     * A value that indicates whether the app successfully delivered an in-app
+     * purchase that works properly.
+     *
+     * Apple-defined values:
+     *   0 - Delivered and working
+     *   1 - Delivered but not working
+     *   2 - Not delivered due to a quality issue
+     *   3 - Not delivered due to a server outage
+     *   4 - Not delivered due to an in-game currency change
+     *   5 - Not delivered for other reasons
+     */
+    public ?int $deliveryStatus = null;
+
+    /**
+     * A value that indicates the extent to which the customer consumed the in-app
+     * purchase (0–100, in increments of 10).
+     */
+    public ?int $consumptionPercentage = null;
+
+    /**
+     * A value that indicates your preference for how the App Store should proceed
+     * when the customer requests a refund.
+     *
+     * Apple-defined values:
+     *   0 - Undeclared (you have no preference)
+     *   1 - No refund
+     *   2 - Grant refund
+     */
+    public ?int $refundPreference = null;
+
+    public function __construct(bool $customerConsented, bool $sampleContentProvided)
+    {
+        $this->customerConsented     = $customerConsented;
+        $this->sampleContentProvided = $sampleContentProvided;
+    }
+
+    /**
+     * Serialize to array for the JSON request body.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $body = [
+            'customerConsented'     => $this->customerConsented,
+            'sampleContentProvided' => $this->sampleContentProvided,
+        ];
+
+        if ($this->deliveryStatus !== null) {
+            $body['deliveryStatus'] = $this->deliveryStatus;
+        }
+
+        if ($this->consumptionPercentage !== null) {
+            $body['consumptionPercentage'] = $this->consumptionPercentage;
+        }
+
+        if ($this->refundPreference !== null) {
+            $body['refundPreference'] = $this->refundPreference;
+        }
+
+        return $body;
+    }
+}

--- a/src/AppleAppStore/ExtendRenewalDateRequest.php
+++ b/src/AppleAppStore/ExtendRenewalDateRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\AppleAppStore;
+
+/**
+ * Request body for the Extend a Subscription Renewal Date endpoint.
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/extend-a-subscription-renewal-date
+ */
+final class ExtendRenewalDateRequest
+{
+    /** The number of days to extend the subscription renewal date (max 90). */
+    public ?int $extendByDays = null;
+
+    /**
+     * The reason code for the extension.
+     *
+     * Apple-defined values:
+     *   0 - Other
+     *   1 - Customer Satisfaction
+     *   2 - Other
+     *   3 - Service Issue or Outage
+     */
+    public ?int $extendReasonCode = null;
+
+    /** A string that contains a unique identifier you provide to track each subscription-renewal-date extension request. */
+    public ?string $requestIdentifier = null;
+
+    /**
+     * Serialize to array for the JSON request body.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $body = [];
+
+        if ($this->extendByDays !== null) {
+            $body['extendByDays'] = $this->extendByDays;
+        }
+
+        if ($this->extendReasonCode !== null) {
+            $body['extendReasonCode'] = $this->extendReasonCode;
+        }
+
+        if ($this->requestIdentifier !== null) {
+            $body['requestIdentifier'] = $this->requestIdentifier;
+        }
+
+        return $body;
+    }
+}

--- a/src/AppleAppStore/ExtendRenewalDateResponse.php
+++ b/src/AppleAppStore/ExtendRenewalDateResponse.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\AppleAppStore;
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use ReceiptValidator\Support\ValueCasting;
+
+/**
+ * Response from the Extend a Subscription Renewal Date endpoint.
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/extend-a-subscription-renewal-date
+ */
+final readonly class ExtendRenewalDateResponse
+{
+    use ValueCasting;
+
+    /** The original transaction identifier of the subscription. */
+    public ?string $originalTransactionId;
+
+    /** A unique identifier for a subscription-purchase event across devices. */
+    public ?string $webOrderLineItemId;
+
+    /** Whether the renewal date extension succeeded. */
+    public bool $success;
+
+    /** The new subscription expiration date after the extension. */
+    public ?CarbonImmutable $effectiveDate;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data = [])
+    {
+        $this->originalTransactionId = $this->toString($data, 'originalTransactionId');
+        $this->webOrderLineItemId    = $this->toString($data, 'webOrderLineItemId');
+        $this->success               = $this->toBool($data, 'success');
+        $this->effectiveDate         = $this->toDateFromMs($data, 'effectiveDate');
+    }
+
+    public function getOriginalTransactionId(): ?string
+    {
+        return $this->originalTransactionId;
+    }
+
+    public function getWebOrderLineItemId(): ?string
+    {
+        return $this->webOrderLineItemId;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public function getEffectiveDate(): ?CarbonInterface
+    {
+        return $this->effectiveDate;
+    }
+}

--- a/src/AppleAppStore/MassExtendRenewalDateRequest.php
+++ b/src/AppleAppStore/MassExtendRenewalDateRequest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\AppleAppStore;
+
+/**
+ * Request body for the Extend Subscription Renewal Dates for All Active Subscribers endpoint.
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/extend-subscription-renewal-dates-for-all-active-subscribers
+ */
+final class MassExtendRenewalDateRequest
+{
+    /** The number of days to extend the subscription renewal date (max 90). */
+    public ?int $extendByDays = null;
+
+    /**
+     * The reason code for the extension.
+     *
+     * Apple-defined values:
+     *   0 - Other
+     *   1 - Customer Satisfaction
+     *   2 - Other
+     *   3 - Service Issue or Outage
+     */
+    public ?int $extendReasonCode = null;
+
+    /** A string that contains a unique identifier you provide to track this mass extension request. */
+    public ?string $requestIdentifier = null;
+
+    /** The product identifier of the auto-renewable subscription to extend. */
+    public ?string $productId = null;
+
+    /**
+     * A list of storefront country codes to limit which subscribers receive the extension.
+     *
+     * @var string[]|null
+     */
+    public ?array $storefrontCountryCodes = null;
+
+    /**
+     * Serialize to array for the JSON request body.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $body = [];
+
+        if ($this->extendByDays !== null) {
+            $body['extendByDays'] = $this->extendByDays;
+        }
+
+        if ($this->extendReasonCode !== null) {
+            $body['extendReasonCode'] = $this->extendReasonCode;
+        }
+
+        if ($this->requestIdentifier !== null) {
+            $body['requestIdentifier'] = $this->requestIdentifier;
+        }
+
+        if ($this->productId !== null) {
+            $body['productId'] = $this->productId;
+        }
+
+        if (!empty($this->storefrontCountryCodes)) {
+            $body['storefrontCountryCodes'] = array_values($this->storefrontCountryCodes);
+        }
+
+        return $body;
+    }
+}

--- a/src/AppleAppStore/MassExtendRenewalDateStatusResponse.php
+++ b/src/AppleAppStore/MassExtendRenewalDateStatusResponse.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\AppleAppStore;
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use ReceiptValidator\Support\ValueCasting;
+
+/**
+ * Response from the Get Status of Subscription Renewal Date Extensions endpoint.
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/get-status-of-subscription-renewal-date-extensions
+ */
+final readonly class MassExtendRenewalDateStatusResponse
+{
+    use ValueCasting;
+
+    /** The unique identifier of the mass extension request. */
+    public ?string $requestIdentifier;
+
+    /** Whether the App Store has finished processing the mass extension. */
+    public bool $complete;
+
+    /** The date the App Store completed processing the extension request. */
+    public ?CarbonImmutable $completeDate;
+
+    /** The count of subscriptions that successfully received the extension. */
+    public ?int $succeededCount;
+
+    /** The count of subscriptions that failed to receive the extension. */
+    public ?int $failedCount;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data = [])
+    {
+        $this->requestIdentifier = $this->toString($data, 'requestIdentifier');
+        $this->complete          = $this->toBool($data, 'complete');
+        $this->completeDate      = $this->toDateFromMs($data, 'completeDate');
+        $this->succeededCount    = $this->toInt($data, 'succeededCount');
+        $this->failedCount       = $this->toInt($data, 'failedCount');
+    }
+
+    public function getRequestIdentifier(): ?string
+    {
+        return $this->requestIdentifier;
+    }
+
+    public function isComplete(): bool
+    {
+        return $this->complete;
+    }
+
+    public function getCompleteDate(): ?CarbonInterface
+    {
+        return $this->completeDate;
+    }
+
+    public function getSucceededCount(): ?int
+    {
+        return $this->succeededCount;
+    }
+
+    public function getFailedCount(): ?int
+    {
+        return $this->failedCount;
+    }
+}

--- a/src/AppleAppStore/RefundHistoryResponse.php
+++ b/src/AppleAppStore/RefundHistoryResponse.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\AppleAppStore;
+
+use ReceiptValidator\Support\ValueCasting;
+
+/**
+ * Response from the Get Refund History endpoint.
+ *
+ * Contains up to 20 refunded or revoked transactions per page, sorted by
+ * revocation date ascending. Use {@see $revision} with subsequent requests
+ * to paginate through the full history.
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/get-refund-history
+ */
+final class RefundHistoryResponse
+{
+    use ValueCasting;
+
+    /**
+     * The decoded refunded transactions for this page.
+     *
+     * @var list<Transaction>
+     */
+    public readonly array $signedTransactions;
+
+    /** A token to pass as the revision query parameter on the next request, or null when unavailable. */
+    public readonly ?string $revision;
+
+    /** Whether more pages of refund history are available. */
+    public readonly bool $hasMore;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data = [])
+    {
+        $this->revision = $this->toString($data, 'revision');
+        $this->hasMore  = $this->toBool($data, 'hasMore');
+
+        $raw = is_array($data['signedTransactions'] ?? null) ? $data['signedTransactions'] : [];
+
+        $transactions = [];
+        foreach ($raw as $jws) {
+            if (!is_string($jws) || $jws === '') {
+                continue;
+            }
+            try {
+                $token    = TokenGenerator::decodeToken($jws);
+                $verifier = new TokenVerifier();
+                if ($verifier->verify($token)) {
+                    $transactions[] = new Transaction($token->claims()->all());
+                }
+            } catch (\Throwable) {
+                // Skip tokens that cannot be decoded or verified
+            }
+        }
+
+        $this->signedTransactions = $transactions;
+    }
+
+    /**
+     * @return list<Transaction>
+     */
+    public function getSignedTransactions(): array
+    {
+        return $this->signedTransactions;
+    }
+
+    public function getRevision(): ?string
+    {
+        return $this->revision;
+    }
+
+    public function hasMore(): bool
+    {
+        return $this->hasMore;
+    }
+}

--- a/src/AppleAppStore/Validator.php
+++ b/src/AppleAppStore/Validator.php
@@ -18,6 +18,7 @@ use ReceiptValidator\Environment;
 use ReceiptValidator\Exceptions\ValidationException;
 use Throwable;
 
+
 /**
  * App Store Server API Validator.
  */
@@ -234,6 +235,7 @@ class Validator extends AbstractValidator
                 'method'      => $method,
                 'uri'         => $uri,
                 'environment' => $this->environment->value,
+                'query'       => $queryParams,
             ]);
 
             return [];
@@ -247,6 +249,7 @@ class Validator extends AbstractValidator
             'method'      => $method,
             'uri'         => $uri,
             'environment' => $this->environment->value,
+            'query'       => $queryParams,
         ]);
 
         return $decoded;
@@ -338,7 +341,7 @@ class Validator extends AbstractValidator
     }
 
     /**
-     * Get the app transaction info for the currently authenticated customer.
+     * Get the app transaction info for the given transaction.
      *
      * Returns a signed app-level transaction that records the customer's original
      * purchase of the app, including the first-install version and purchase date.
@@ -346,17 +349,19 @@ class Validator extends AbstractValidator
      *
      * @see https://developer.apple.com/documentation/appstoreserverapi/get-app-transaction-info
      *
+     * @param string $transactionId The transactionId, originalTransactionId, or appTransactionId.
      * @throws ValidationException
      */
-    public function getAppTransactionInfo(): AppTransaction
+    public function getAppTransactionInfo(string $transactionId): AppTransaction
     {
-        $data = $this->makeRawRequest('GET', '/inApps/v2/transactions/appTransaction');
+        $uri  = sprintf('/inApps/v1/transactions/appTransactions/%s', $transactionId);
+        $data = $this->makeRawRequest('GET', $uri);
 
-        if (empty($data['signedTransactionInfo']) || !is_string($data['signedTransactionInfo'])) {
-            throw new ValidationException('Missing or invalid signedTransactionInfo in app transaction response.');
+        if (empty($data['signedAppTransactionInfo']) || !is_string($data['signedAppTransactionInfo'])) {
+            throw new ValidationException('Missing or invalid signedAppTransactionInfo in app transaction response.');
         }
 
-        $token    = TokenGenerator::decodeToken($data['signedTransactionInfo']);
+        $token    = TokenGenerator::decodeToken($data['signedAppTransactionInfo']);
         $verifier = new TokenVerifier();
 
         if (!$verifier->verify($token)) {
@@ -390,7 +395,7 @@ class Validator extends AbstractValidator
             );
         }
 
-        $uri = sprintf('/inApps/v2/transactions/%s/appAccountToken', $transactionId);
+        $uri = sprintf('/inApps/v1/transactions/%s/appAccountToken', $transactionId);
 
         $this->makeRawRequest('PUT', $uri, [], ['appAccountToken' => $appAccountToken]);
     }
@@ -419,9 +424,96 @@ class Validator extends AbstractValidator
      */
     public function getAllSubscriptionStatuses(string $originalTransactionId): SubscriptionStatusResponse
     {
-        $uri = sprintf('/inApps/v2/subscriptions/%s', $originalTransactionId);
+        $uri = sprintf('/inApps/v1/subscriptions/%s', $originalTransactionId);
 
         return new SubscriptionStatusResponse($this->makeRawRequest('GET', $uri));
+    }
+
+    /**
+     * Get the refund history for a customer identified by a transaction ID.
+     *
+     * Returns up to 20 refunded or revoked transactions per call, sorted by revocation
+     * date ascending. When {@see RefundHistoryResponse::$hasMore} is true, pass the
+     * returned {@see RefundHistoryResponse::$revision} back as the $revision parameter
+     * to fetch the next page.
+     *
+     * @see https://developer.apple.com/documentation/appstoreserverapi/get-refund-history
+     *
+     * @throws ValidationException
+     */
+    public function getRefundHistory(string $transactionId, ?string $revision = null): RefundHistoryResponse
+    {
+        $uri         = sprintf('/inApps/v2/refund/lookup/%s', $transactionId);
+        $queryParams = $revision !== null ? ['revision' => $revision] : [];
+
+        return new RefundHistoryResponse($this->makeRawRequest('GET', $uri, $queryParams));
+    }
+
+    /**
+     * Extend the renewal date for a single auto-renewable subscription.
+     *
+     * @see https://developer.apple.com/documentation/appstoreserverapi/extend-a-subscription-renewal-date
+     *
+     * @throws ValidationException
+     */
+    public function extendSubscriptionRenewalDate(
+        string $originalTransactionId,
+        ExtendRenewalDateRequest $request,
+    ): ExtendRenewalDateResponse {
+        $uri = sprintf('/inApps/v1/subscriptions/extend/%s', $originalTransactionId);
+
+        return new ExtendRenewalDateResponse($this->makeRawRequest('PUT', $uri, [], $request->toArray()));
+    }
+
+    /**
+     * Extend subscription renewal dates for all active subscribers of a product.
+     *
+     * Returns the requestIdentifier that you can use with
+     * {@see getStatusOfSubscriptionRenewalDateExtensions()} to track progress.
+     *
+     * @see https://developer.apple.com/documentation/appstoreserverapi/extend-subscription-renewal-dates-for-all-active-subscribers
+     *
+     * @throws ValidationException
+     */
+    public function extendSubscriptionRenewalDatesForAllActiveSubscribers(
+        MassExtendRenewalDateRequest $request,
+    ): string {
+        $data = $this->makeRawRequest('POST', '/inApps/v1/subscriptions/extend/mass', [], $request->toArray());
+
+        return (string) ($data['requestIdentifier'] ?? '');
+    }
+
+    /**
+     * Get the status of a previously requested mass subscription renewal date extension.
+     *
+     * @see https://developer.apple.com/documentation/appstoreserverapi/get-status-of-subscription-renewal-date-extensions
+     *
+     * @throws ValidationException
+     */
+    public function getStatusOfSubscriptionRenewalDateExtensions(
+        string $productId,
+        string $requestIdentifier,
+    ): MassExtendRenewalDateStatusResponse {
+        $uri = sprintf('/inApps/v1/subscriptions/extend/mass/%s/%s', $productId, $requestIdentifier);
+
+        return new MassExtendRenewalDateStatusResponse($this->makeRawRequest('GET', $uri));
+    }
+
+    /**
+     * Send consumption information for a consumable in-app purchase to the App Store.
+     *
+     * This informs Apple about how much of a consumable purchase a customer has used,
+     * which Apple considers when deciding whether to grant a refund request.
+     *
+     * @see https://developer.apple.com/documentation/appstoreserverapi/send-consumption-information
+     *
+     * @throws ValidationException
+     */
+    public function sendConsumptionInformation(string $transactionId, ConsumptionRequest $request): void
+    {
+        $uri = sprintf('/inApps/v2/transactions/consumption/%s', $transactionId);
+
+        $this->makeRawRequest('PUT', $uri, [], $request->toArray());
     }
 
     /**

--- a/src/AppleAppStore/Validator.php
+++ b/src/AppleAppStore/Validator.php
@@ -18,7 +18,6 @@ use ReceiptValidator\Environment;
 use ReceiptValidator\Exceptions\ValidationException;
 use Throwable;
 
-
 /**
  * App Store Server API Validator.
  */

--- a/tests/AppleAppStore/AppTransactionTest.php
+++ b/tests/AppleAppStore/AppTransactionTest.php
@@ -61,7 +61,7 @@ final class AppTransactionTest extends TestCase
             ->method('sendRequest')
             ->with($this->callback(function (RequestInterface $request): bool {
                 return $request->getMethod() === 'GET'
-                    && str_contains((string) $request->getUri(), '/inApps/v2/transactions/appTransaction');
+                    && str_contains((string) $request->getUri(), '/inApps/v1/transactions/appTransactions/txn-abc');
             }))
             ->willReturn(new GuzzleResponse(400, [], json_encode([
                 'errorCode'    => 4290000,
@@ -70,7 +70,7 @@ final class AppTransactionTest extends TestCase
 
         // We only care that the correct endpoint was called; the 400 throws an exception.
         $this->expectException(ValidationException::class);
-        $this->validator->getAppTransactionInfo();
+        $this->validator->getAppTransactionInfo('txn-abc');
     }
 
     /**
@@ -83,8 +83,8 @@ final class AppTransactionTest extends TestCase
             ->willReturn(new GuzzleResponse(200, [], json_encode([], JSON_THROW_ON_ERROR)));
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Missing or invalid signedTransactionInfo');
-        $this->validator->getAppTransactionInfo();
+        $this->expectExceptionMessage('Missing or invalid signedAppTransactionInfo');
+        $this->validator->getAppTransactionInfo('txn-abc');
     }
 
     // -------------------------------------------------------------------------

--- a/tests/AppleAppStore/ExtendRenewalDateTest.php
+++ b/tests/AppleAppStore/ExtendRenewalDateTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\Tests\AppleAppStore;
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use ReceiptValidator\AppleAppStore\ExtendRenewalDateRequest;
+use ReceiptValidator\AppleAppStore\ExtendRenewalDateResponse;
+use ReceiptValidator\AppleAppStore\Validator;
+use ReceiptValidator\Environment;
+use ReceiptValidator\Exceptions\ValidationException;
+
+/**
+ * @group apple-app-store
+ */
+#[CoversClass(Validator::class)]
+#[CoversClass(ExtendRenewalDateRequest::class)]
+#[CoversClass(ExtendRenewalDateResponse::class)]
+final class ExtendRenewalDateTest extends TestCase
+{
+    private Validator $validator;
+    private ClientInterface $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockClient = $this->createStub(ClientInterface::class);
+        $signingKey       = (string) file_get_contents(__DIR__ . '/certs/testSigningKey.p8');
+
+        $this->validator = new Validator(
+            signingKey: $signingKey,
+            keyId: 'ABC123XYZ',
+            issuerId: 'DEF456UVW',
+            bundleId: 'com.example',
+            environment: Environment::SANDBOX,
+        );
+        $this->validator->setHttpClient($this->mockClient);
+    }
+
+    /**
+     * @covers \ReceiptValidator\AppleAppStore\Validator::extendSubscriptionRenewalDate
+     * @covers \ReceiptValidator\AppleAppStore\Validator::makeRawRequest
+     */
+    public function testExtendRenewalDateCallsCorrectEndpoint(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                return $request->getMethod() === 'PUT'
+                    && str_contains((string) $request->getUri(), '/inApps/v1/subscriptions/extend/orig-txn-001');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'originalTransactionId' => 'orig-txn-001',
+                'webOrderLineItemId'    => 'woli-123',
+                'success'               => true,
+                'effectiveDate'         => 1700000000000,
+            ], JSON_THROW_ON_ERROR)));
+
+        $request               = new ExtendRenewalDateRequest();
+        $request->extendByDays = 30;
+
+        $response = $this->validator->extendSubscriptionRenewalDate('orig-txn-001', $request);
+        self::assertInstanceOf(ExtendRenewalDateResponse::class, $response);
+    }
+
+    public function testExtendRenewalDateSendsJsonBody(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                $body    = (string) $request->getBody();
+                $decoded = json_decode($body, true);
+
+                return is_array($decoded)
+                    && ($decoded['extendByDays'] ?? null) === 14
+                    && ($decoded['extendReasonCode'] ?? null) === 1
+                    && str_contains($request->getHeaderLine('Content-Type'), 'application/json');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'originalTransactionId' => 'orig-txn-001',
+                'success'               => true,
+            ], JSON_THROW_ON_ERROR)));
+
+        $request                   = new ExtendRenewalDateRequest();
+        $request->extendByDays     = 14;
+        $request->extendReasonCode = 1;
+
+        $this->validator->extendSubscriptionRenewalDate('orig-txn-001', $request);
+    }
+
+    public function testExtendRenewalDateThrowsOnApiError(): void
+    {
+        $this->mockClient
+            ->method('sendRequest')
+            ->willReturn(new GuzzleResponse(401, [], ''));
+
+        $this->expectException(ValidationException::class);
+        $this->validator->extendSubscriptionRenewalDate('orig-txn-001', new ExtendRenewalDateRequest());
+    }
+
+    // -------------------------------------------------------------------------
+    // ExtendRenewalDateResponse parsing
+    // -------------------------------------------------------------------------
+
+    public function testExtendRenewalDateResponseParsesFields(): void
+    {
+        $response = new ExtendRenewalDateResponse([
+            'originalTransactionId' => 'orig-txn-001',
+            'webOrderLineItemId'    => 'woli-abc',
+            'success'               => true,
+            'effectiveDate'         => 1700000000000,
+        ]);
+
+        self::assertSame('orig-txn-001', $response->getOriginalTransactionId());
+        self::assertSame('woli-abc', $response->getWebOrderLineItemId());
+        self::assertTrue($response->isSuccess());
+        self::assertNotNull($response->getEffectiveDate());
+    }
+
+    public function testExtendRenewalDateResponseHandlesMissingFields(): void
+    {
+        $response = new ExtendRenewalDateResponse([]);
+
+        self::assertNull($response->getOriginalTransactionId());
+        self::assertNull($response->getWebOrderLineItemId());
+        self::assertFalse($response->isSuccess());
+        self::assertNull($response->getEffectiveDate());
+    }
+
+    // -------------------------------------------------------------------------
+    // ExtendRenewalDateRequest serialization
+    // -------------------------------------------------------------------------
+
+    public function testRequestToArrayOmitsNullFields(): void
+    {
+        $request = new ExtendRenewalDateRequest();
+        self::assertSame([], $request->toArray());
+    }
+
+    public function testRequestToArrayIncludesSetFields(): void
+    {
+        $request                      = new ExtendRenewalDateRequest();
+        $request->extendByDays        = 7;
+        $request->extendReasonCode    = 3;
+        $request->requestIdentifier   = 'req-uuid-123';
+
+        $body = $request->toArray();
+        self::assertSame(7, $body['extendByDays']);
+        self::assertSame(3, $body['extendReasonCode']);
+        self::assertSame('req-uuid-123', $body['requestIdentifier']);
+    }
+}

--- a/tests/AppleAppStore/GetRefundHistoryTest.php
+++ b/tests/AppleAppStore/GetRefundHistoryTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\Tests\AppleAppStore;
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use ReceiptValidator\AppleAppStore\RefundHistoryResponse;
+use ReceiptValidator\AppleAppStore\Validator;
+use ReceiptValidator\Environment;
+use ReceiptValidator\Exceptions\ValidationException;
+
+/**
+ * @group apple-app-store
+ */
+#[CoversClass(Validator::class)]
+#[CoversClass(RefundHistoryResponse::class)]
+final class GetRefundHistoryTest extends TestCase
+{
+    private Validator $validator;
+    private ClientInterface $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockClient = $this->createStub(ClientInterface::class);
+        $signingKey       = (string) file_get_contents(__DIR__ . '/certs/testSigningKey.p8');
+
+        $this->validator = new Validator(
+            signingKey: $signingKey,
+            keyId: 'ABC123XYZ',
+            issuerId: 'DEF456UVW',
+            bundleId: 'com.example',
+            environment: Environment::SANDBOX,
+        );
+        $this->validator->setHttpClient($this->mockClient);
+    }
+
+    /**
+     * @covers \ReceiptValidator\AppleAppStore\Validator::getRefundHistory
+     * @covers \ReceiptValidator\AppleAppStore\Validator::makeRawRequest
+     */
+    public function testGetRefundHistoryCallsCorrectEndpoint(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                return $request->getMethod() === 'GET'
+                    && str_contains((string) $request->getUri(), '/inApps/v2/refund/lookup/txn-abc123');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'signedTransactions' => [],
+                'revision'           => null,
+                'hasMore'            => false,
+            ], JSON_THROW_ON_ERROR)));
+
+        $response = $this->validator->getRefundHistory('txn-abc123');
+        self::assertInstanceOf(RefundHistoryResponse::class, $response);
+    }
+
+    public function testGetRefundHistoryPassesRevisionQueryParam(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                return str_contains((string) $request->getUri(), 'revision=page2token');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'signedTransactions' => [],
+                'hasMore'            => false,
+            ], JSON_THROW_ON_ERROR)));
+
+        $this->validator->getRefundHistory('txn-abc123', 'page2token');
+    }
+
+    public function testGetRefundHistoryThrowsOnApiError(): void
+    {
+        $this->mockClient
+            ->method('sendRequest')
+            ->willReturn(new GuzzleResponse(401, [], ''));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Unauthenticated');
+        $this->validator->getRefundHistory('txn-abc123');
+    }
+
+    // -------------------------------------------------------------------------
+    // RefundHistoryResponse parsing
+    // -------------------------------------------------------------------------
+
+    public function testRefundHistoryResponseParsesEmptyTransactions(): void
+    {
+        $response = new RefundHistoryResponse([
+            'signedTransactions' => [],
+            'revision'           => 'token-abc',
+            'hasMore'            => true,
+        ]);
+
+        self::assertSame([], $response->getSignedTransactions());
+        self::assertSame('token-abc', $response->getRevision());
+        self::assertTrue($response->hasMore());
+    }
+
+    public function testRefundHistoryResponseHandlesMissingFields(): void
+    {
+        $response = new RefundHistoryResponse([]);
+
+        self::assertSame([], $response->getSignedTransactions());
+        self::assertNull($response->getRevision());
+        self::assertFalse($response->hasMore());
+    }
+
+    public function testRefundHistoryResponseSkipsInvalidJwsTokens(): void
+    {
+        $response = new RefundHistoryResponse([
+            'signedTransactions' => ['not-a-valid-jws', '', 42],
+            'hasMore'            => false,
+        ]);
+
+        // Invalid tokens are silently skipped
+        self::assertSame([], $response->getSignedTransactions());
+    }
+}

--- a/tests/AppleAppStore/MassExtendRenewalDateTest.php
+++ b/tests/AppleAppStore/MassExtendRenewalDateTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\Tests\AppleAppStore;
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use ReceiptValidator\AppleAppStore\MassExtendRenewalDateRequest;
+use ReceiptValidator\AppleAppStore\MassExtendRenewalDateStatusResponse;
+use ReceiptValidator\AppleAppStore\Validator;
+use ReceiptValidator\Environment;
+use ReceiptValidator\Exceptions\ValidationException;
+
+/**
+ * @group apple-app-store
+ */
+#[CoversClass(Validator::class)]
+#[CoversClass(MassExtendRenewalDateRequest::class)]
+#[CoversClass(MassExtendRenewalDateStatusResponse::class)]
+final class MassExtendRenewalDateTest extends TestCase
+{
+    private Validator $validator;
+    private ClientInterface $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockClient = $this->createStub(ClientInterface::class);
+        $signingKey       = (string) file_get_contents(__DIR__ . '/certs/testSigningKey.p8');
+
+        $this->validator = new Validator(
+            signingKey: $signingKey,
+            keyId: 'ABC123XYZ',
+            issuerId: 'DEF456UVW',
+            bundleId: 'com.example',
+            environment: Environment::SANDBOX,
+        );
+        $this->validator->setHttpClient($this->mockClient);
+    }
+
+    // -------------------------------------------------------------------------
+    // extendSubscriptionRenewalDatesForAllActiveSubscribers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @covers \ReceiptValidator\AppleAppStore\Validator::extendSubscriptionRenewalDatesForAllActiveSubscribers
+     * @covers \ReceiptValidator\AppleAppStore\Validator::makeRawRequest
+     */
+    public function testMassExtendCallsCorrectEndpoint(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                return $request->getMethod() === 'POST'
+                    && str_contains((string) $request->getUri(), '/inApps/v1/subscriptions/extend/mass')
+                    && !str_contains((string) $request->getUri(), '/inApps/v1/subscriptions/extend/mass/');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'requestIdentifier' => 'req-uuid-abc',
+            ], JSON_THROW_ON_ERROR)));
+
+        $request                    = new MassExtendRenewalDateRequest();
+        $request->extendByDays      = 30;
+        $request->productId         = 'com.example.pro';
+        $request->requestIdentifier = 'req-uuid-abc';
+
+        $id = $this->validator->extendSubscriptionRenewalDatesForAllActiveSubscribers($request);
+        self::assertSame('req-uuid-abc', $id);
+    }
+
+    public function testMassExtendSendsJsonBody(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                $decoded = json_decode((string) $request->getBody(), true);
+
+                return is_array($decoded)
+                    && ($decoded['extendByDays'] ?? null) === 15
+                    && ($decoded['productId'] ?? null) === 'com.example.monthly'
+                    && ($decoded['storefrontCountryCodes'] ?? null) === ['US', 'GB']
+                    && str_contains($request->getHeaderLine('Content-Type'), 'application/json');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'requestIdentifier' => 'req-1',
+            ], JSON_THROW_ON_ERROR)));
+
+        $request                         = new MassExtendRenewalDateRequest();
+        $request->extendByDays           = 15;
+        $request->productId              = 'com.example.monthly';
+        $request->storefrontCountryCodes = ['US', 'GB'];
+
+        $this->validator->extendSubscriptionRenewalDatesForAllActiveSubscribers($request);
+    }
+
+    public function testMassExtendThrowsOnApiError(): void
+    {
+        $this->mockClient
+            ->method('sendRequest')
+            ->willReturn(new GuzzleResponse(401, [], ''));
+
+        $this->expectException(ValidationException::class);
+        $this->validator->extendSubscriptionRenewalDatesForAllActiveSubscribers(new MassExtendRenewalDateRequest());
+    }
+
+    // -------------------------------------------------------------------------
+    // getStatusOfSubscriptionRenewalDateExtensions
+    // -------------------------------------------------------------------------
+
+    /**
+     * @covers \ReceiptValidator\AppleAppStore\Validator::getStatusOfSubscriptionRenewalDateExtensions
+     */
+    public function testGetStatusCallsCorrectEndpoint(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                return $request->getMethod() === 'GET'
+                    && str_contains(
+                        (string) $request->getUri(),
+                        '/inApps/v1/subscriptions/extend/mass/com.example.pro/req-uuid-abc'
+                    );
+            }))
+            ->willReturn(new GuzzleResponse(200, [], json_encode([
+                'requestIdentifier' => 'req-uuid-abc',
+                'complete'          => true,
+                'completeDate'      => 1700000000000,
+                'succeededCount'    => 150,
+                'failedCount'       => 2,
+            ], JSON_THROW_ON_ERROR)));
+
+        $response = $this->validator->getStatusOfSubscriptionRenewalDateExtensions('com.example.pro', 'req-uuid-abc');
+        self::assertInstanceOf(MassExtendRenewalDateStatusResponse::class, $response);
+    }
+
+    public function testGetStatusThrowsOnApiError(): void
+    {
+        $this->mockClient
+            ->method('sendRequest')
+            ->willReturn(new GuzzleResponse(404, [], ''));
+
+        $this->expectException(ValidationException::class);
+        $this->validator->getStatusOfSubscriptionRenewalDateExtensions('com.example.pro', 'req-uuid-abc');
+    }
+
+    // -------------------------------------------------------------------------
+    // MassExtendRenewalDateStatusResponse parsing
+    // -------------------------------------------------------------------------
+
+    public function testStatusResponseParsesFields(): void
+    {
+        $response = new MassExtendRenewalDateStatusResponse([
+            'requestIdentifier' => 'req-uuid-abc',
+            'complete'          => true,
+            'completeDate'      => 1700000000000,
+            'succeededCount'    => 150,
+            'failedCount'       => 2,
+        ]);
+
+        self::assertSame('req-uuid-abc', $response->getRequestIdentifier());
+        self::assertTrue($response->isComplete());
+        self::assertNotNull($response->getCompleteDate());
+        self::assertSame(150, $response->getSucceededCount());
+        self::assertSame(2, $response->getFailedCount());
+    }
+
+    public function testStatusResponseHandlesMissingFields(): void
+    {
+        $response = new MassExtendRenewalDateStatusResponse([]);
+
+        self::assertNull($response->getRequestIdentifier());
+        self::assertFalse($response->isComplete());
+        self::assertNull($response->getCompleteDate());
+        self::assertNull($response->getSucceededCount());
+        self::assertNull($response->getFailedCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // MassExtendRenewalDateRequest serialization
+    // -------------------------------------------------------------------------
+
+    public function testRequestToArrayOmitsNullFields(): void
+    {
+        $request = new MassExtendRenewalDateRequest();
+        self::assertSame([], $request->toArray());
+    }
+
+    public function testRequestToArrayIncludesSetFields(): void
+    {
+        $request                         = new MassExtendRenewalDateRequest();
+        $request->extendByDays           = 30;
+        $request->extendReasonCode       = 1;
+        $request->requestIdentifier      = 'req-uuid-xyz';
+        $request->productId              = 'com.example.pro';
+        $request->storefrontCountryCodes = ['US', 'CA'];
+
+        $body = $request->toArray();
+        self::assertSame(30, $body['extendByDays']);
+        self::assertSame(1, $body['extendReasonCode']);
+        self::assertSame('req-uuid-xyz', $body['requestIdentifier']);
+        self::assertSame('com.example.pro', $body['productId']);
+        self::assertSame(['US', 'CA'], $body['storefrontCountryCodes']);
+    }
+}

--- a/tests/AppleAppStore/SendConsumptionInformationTest.php
+++ b/tests/AppleAppStore/SendConsumptionInformationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ReceiptValidator\Tests\AppleAppStore;
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use ReceiptValidator\AppleAppStore\ConsumptionRequest;
+use ReceiptValidator\AppleAppStore\Validator;
+use ReceiptValidator\Environment;
+use ReceiptValidator\Exceptions\ValidationException;
+
+/**
+ * @group apple-app-store
+ */
+#[CoversClass(Validator::class)]
+#[CoversClass(ConsumptionRequest::class)]
+final class SendConsumptionInformationTest extends TestCase
+{
+    private Validator $validator;
+    private ClientInterface $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockClient = $this->createStub(ClientInterface::class);
+        $signingKey       = (string) file_get_contents(__DIR__ . '/certs/testSigningKey.p8');
+
+        $this->validator = new Validator(
+            signingKey: $signingKey,
+            keyId: 'ABC123XYZ',
+            issuerId: 'DEF456UVW',
+            bundleId: 'com.example',
+            environment: Environment::SANDBOX,
+        );
+        $this->validator->setHttpClient($this->mockClient);
+    }
+
+    /**
+     * @covers \ReceiptValidator\AppleAppStore\Validator::sendConsumptionInformation
+     * @covers \ReceiptValidator\AppleAppStore\Validator::makeRawRequest
+     */
+    public function testSendConsumptionInformationCallsCorrectEndpoint(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                return $request->getMethod() === 'PUT'
+                    && str_contains((string) $request->getUri(), '/inApps/v2/transactions/consumption/txn-abc123');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], ''));
+
+        $request = new ConsumptionRequest(customerConsented: true, sampleContentProvided: false);
+        $this->validator->sendConsumptionInformation('txn-abc123', $request);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testSendConsumptionInformationSendsCorrectJsonBody(): void
+    {
+        $mockClient = $this->createMock(ClientInterface::class);
+        $this->validator->setHttpClient($mockClient);
+
+        $mockClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request): bool {
+                $decoded = json_decode((string) $request->getBody(), true);
+
+                return is_array($decoded)
+                    && ($decoded['customerConsented'] ?? null) === true
+                    && ($decoded['sampleContentProvided'] ?? null) === false
+                    && ($decoded['deliveryStatus'] ?? null) === 0
+                    && ($decoded['consumptionPercentage'] ?? null) === 50
+                    && ($decoded['refundPreference'] ?? null) === 1
+                    && str_contains($request->getHeaderLine('Content-Type'), 'application/json');
+            }))
+            ->willReturn(new GuzzleResponse(200, [], ''));
+
+        $request                       = new ConsumptionRequest(customerConsented: true, sampleContentProvided: false);
+        $request->deliveryStatus       = 0;
+        $request->consumptionPercentage = 50;
+        $request->refundPreference     = 1;
+
+        $this->validator->sendConsumptionInformation('txn-abc123', $request);
+    }
+
+    public function testSendConsumptionInformationThrowsOnApiError(): void
+    {
+        $this->mockClient
+            ->method('sendRequest')
+            ->willReturn(new GuzzleResponse(401, [], ''));
+
+        $this->expectException(ValidationException::class);
+        $request = new ConsumptionRequest(customerConsented: true, sampleContentProvided: true);
+        $this->validator->sendConsumptionInformation('txn-abc123', $request);
+    }
+
+    // -------------------------------------------------------------------------
+    // ConsumptionRequest serialization
+    // -------------------------------------------------------------------------
+
+    public function testRequestToArrayIncludesRequiredFields(): void
+    {
+        $request = new ConsumptionRequest(customerConsented: true, sampleContentProvided: false);
+        $body    = $request->toArray();
+
+        self::assertTrue($body['customerConsented']);
+        self::assertFalse($body['sampleContentProvided']);
+        self::assertArrayNotHasKey('deliveryStatus', $body);
+        self::assertArrayNotHasKey('consumptionPercentage', $body);
+        self::assertArrayNotHasKey('refundPreference', $body);
+    }
+
+    public function testRequestToArrayIncludesOptionalFieldsWhenSet(): void
+    {
+        $request                        = new ConsumptionRequest(customerConsented: false, sampleContentProvided: true);
+        $request->deliveryStatus        = 2;
+        $request->consumptionPercentage = 80;
+        $request->refundPreference      = 2;
+
+        $body = $request->toArray();
+
+        self::assertFalse($body['customerConsented']);
+        self::assertTrue($body['sampleContentProvided']);
+        self::assertSame(2, $body['deliveryStatus']);
+        self::assertSame(80, $body['consumptionPercentage']);
+        self::assertSame(2, $body['refundPreference']);
+    }
+}

--- a/tests/AppleAppStore/SetAppAccountTokenTest.php
+++ b/tests/AppleAppStore/SetAppAccountTokenTest.php
@@ -60,7 +60,7 @@ final class SetAppAccountTokenTest extends TestCase
                 return $request->getMethod() === 'PUT'
                     && str_contains(
                         (string) $request->getUri(),
-                        '/inApps/v2/transactions/' . self::TRANSACTION . '/appAccountToken'
+                        '/inApps/v1/transactions/' . self::TRANSACTION . '/appAccountToken'
                     );
             }))
             ->willReturn(new GuzzleResponse(200, [], ''));

--- a/tests/AppleAppStore/SubscriptionStatusTest.php
+++ b/tests/AppleAppStore/SubscriptionStatusTest.php
@@ -66,7 +66,7 @@ final class SubscriptionStatusTest extends TestCase
             ->method('sendRequest')
             ->with($this->callback(function (RequestInterface $request): bool {
                 return $request->getMethod() === 'GET'
-                    && str_contains((string) $request->getUri(), '/inApps/v2/subscriptions/1000000000000001');
+                    && str_contains((string) $request->getUri(), '/inApps/v1/subscriptions/1000000000000001');
             }))
             ->willReturn(new GuzzleResponse(200, [], $json));
 


### PR DESCRIPTION
## Summary
This PR adds support for four new Apple App Store Server API endpoints to the receipt validator library, enabling developers to manage subscription renewal dates, retrieve refund history, and send consumption information.

## Key Changes

### New Endpoints
- **Extend Subscription Renewal Date** - Extend a single subscription's renewal date with `extendSubscriptionRenewalDate()`
- **Mass Extend Renewal Dates** - Extend renewal dates for all active subscribers of a product with `extendSubscriptionRenewalDatesForAllActiveSubscribers()`
- **Get Refund History** - Retrieve refund/revocation history for a transaction with `getRefundHistory()`
- **Send Consumption Information** - Report in-app purchase consumption data with `sendConsumptionInformation()`

### New Request/Response Classes
- `ExtendRenewalDateRequest` - Request body for single subscription extension
- `ExtendRenewalDateResponse` - Response with extension result and effective date
- `MassExtendRenewalDateRequest` - Request body for mass extension with optional country filtering
- `MassExtendRenewalDateStatusResponse` - Status response for mass extension operations
- `ConsumptionRequest` - Request body for consumption information with delivery status and refund preference
- `RefundHistoryResponse` - Paginated refund history with transaction decoding and verification

### API Updates
- Fixed `getAppTransactionInfo()` to accept a `transactionId` parameter and use correct endpoint `/inApps/v1/transactions/appTransactions/{id}`
- Updated `setAppAccountToken()` endpoint from `/inApps/v2/` to `/inApps/v1/`
- Updated `getAllSubscriptionStatuses()` endpoint from `/inApps/v2/` to `/inApps/v1/`
- Enhanced `makeRawRequest()` to include query parameters in debug logging

### Implementation Details
- All request classes follow the existing pattern with nullable properties and `toArray()` serialization
- Response classes use the `ValueCasting` trait for consistent type conversion
- `RefundHistoryResponse` automatically decodes and verifies JWS tokens, silently skipping invalid ones
- Mass extension requests support optional storefront country code filtering
- Comprehensive test coverage with 4 new test files covering all endpoints and edge cases

https://claude.ai/code/session_014XzWnwmPdfVfcjsMDDJHb2